### PR TITLE
docs: bookings need a callback number; structured slots are the safer path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,9 @@ curl -s -X POST https://api.voygr.tech/calls \
   (name, date, time, party_size)/`cancellation` (`booking_id`, no phone). A 422
   `missing_slots` lists each gap with a `suggested_question` — refill and
   resubmit. This path returns a FLAT envelope (top-level `call_id`). Schema:
-  `GET /skills/{id}/manifest`.
+  `GET /skills/{id}/manifest`. **Prefer it for bookings** — slots are checked
+  before anything is dialed, and the optional `phone_to_dictate` slot gives the
+  bot a callback number to read back (staff ask for one more often than not).
 
 ## Follow the call (poll; don't hold the stream open)
 Poll `GET /calls/{id}/events?after_event_id=N` with `--max-time 5`, tracking the

--- a/skills/callwright/SKILL.md
+++ b/skills/callwright/SKILL.md
@@ -129,8 +129,17 @@ curl -s -X POST https://api.voygr.tech/calls \
 - The 2xx envelope on this path is **flat** — a top-level `call_id` (no `call`
   wrapper), plus `status_url` / `answer_url` — follow/poll it exactly like a
   freeform call.
-- Freeform and structured perform equally well — pick whichever fits your agent;
-  don't mix both in one request.
+- **For bookings, prefer this structured path.** Its slots are checked before
+  anything is dialed, so a detail you left out comes back as a `422` you can
+  still fix; on the freeform path the `brief` is taken verbatim and the same gap
+  surfaces mid-call, as a question the bot has to improvise. For inquiries
+  either path is fine — pick whichever fits your agent.
+- **Always give the bot a callback number for a booking.** "What number can we
+  reach you at?" is the question staff ask most often, and a call that cannot
+  answer it tends to end without a confirmed reservation. On `booking` send the
+  optional `phone_to_dictate` slot (the bot reads it back digit by digit); on
+  the freeform path put the number in the `brief`.
+- Don't mix both in one request — send either a `brief` or `intent` + `slots`.
 
 ## Follow the call — poll the event stream (do NOT hold it open)
 


### PR DESCRIPTION
The skill told agents that "freeform and structured perform equally well". That is not what we see in practice for bookings, and the difference costs calls.

The structured path validates its slots before anything is dialed, so a detail the agent left out comes back as a `422` it can still fix. The freeform path takes the `brief` verbatim, so the same gap only surfaces mid-call, as a question the bot has to improvise an answer to. A missing callback number is the common case: "what number can we reach you at?" is the question staff ask most often, and a call that cannot answer it tends to end without a confirmed reservation.

## Changed

- `skills/callwright/SKILL.md` — the parity claim is replaced by three practical bullets: prefer the structured path for bookings, always supply a callback number (the optional `phone_to_dictate` slot on `booking`, or a sentence in the `brief` on the freeform path), and don't mix both in one request. For inquiries either path is still fine.
- `AGENTS.md` — one clause added so the Codex-facing reference carries the same guidance, per this repo's rule that the two stay in step.

`phone_to_dictate` was checked against the server: it is an optional field on the restaurant-reservation input, passed through from `slots`, and the bot reads it back digit by digit.

Docs only. No behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sgz6C23JvTCa56nhDgiXMm
