### PR TITLE
docs: short_list_reason — why a short card list is short

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,11 @@ Only `query` required; `location_hint` needed for "near me" wording;
 Response: `{request_id, intent, suggestions: [{suggestion_id, rank, name,
 address, phone_e164, website, rating, review_count, price_level,
 open_at_target, why, product_match, verify_on_call, call_brief, call_ready}],
-degraded, degradation_reason}` — cards ordered by `rank`, each with its OWN
-`suggestion_id`.
+degraded, degradation_reason, short_list_reason}` — cards ordered by `rank`,
+each with its OWN `suggestion_id`. `short_list_reason` explains a short list:
+`"thin_pool"` = market is thin (comes with `degraded: true`/`few_results`);
+`"curated"` = ranker deliberately picked fewer from a full pool (good sign,
+`degraded` stays false); `null` = list is full.
 Each card bridges to `POST /calls`: `phone_e164` (pre-validated by the same
 normaliser as `target_phone`), `call_brief` (ready-to-send `brief` — read it,
 then send as-is or edit), `suggestion_id` (send back on `POST /calls` to link

--- a/skills/callwright/SKILL.md
+++ b/skills/callwright/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: callwright
 description: Use WHENEVER the user wants to make a phone call, call a number, ask a business something by phone, book or cancel a reservation, find a place or business to call when no phone number is at hand ("find me a florist and call them"), check a call's status/outcome, or answer a question the call bot asked mid-call. Places REAL outbound voice calls via the callwright REST API and follows the call. Always consult this skill before saying you cannot make calls or find businesses to call.
-version: 5.3.0
+version: 5.3.1
 author: voygr-tech
 license: MIT
 platforms: [linux, macos, windows]
@@ -199,7 +199,8 @@ curl -s -X POST https://api.voygr.tech/v1/places/suggest \
       "call_brief": "Call Fleur Chicago. Ask whether they have fresh peonies available this week. Ask the price. Do not place an order — just report back. Callback number +13125550188.",
       "call_ready": true } ],
   "degraded": false,
-  "degradation_reason": null
+  "degradation_reason": null,
+  "short_list_reason": null
 }
 ```
 
@@ -252,6 +253,13 @@ same response may be called too — every linked call records its own outcome.
   `degradation_reason` (`relaxed_thresholds` | `few_results` | `rank_fallback`
   | `partial_timeout`) — the answer is weaker in exactly that way; tell your
   user which, don't hide it.
+- `short_list_reason` — why you got fewer cards than `limit`, when you did:
+  `"thin_pool"` = the market is genuinely thin, this is all there is (always
+  comes with `degraded: true` / `few_results` — widen the area or accept);
+  `"curated"` = plenty of places qualified, the ranker deliberately picked
+  fewer because the rest fit worse — a GOOD sign (quality selection, not an
+  error; `degraded` stays `false`). `null` = the list is full. The field is
+  always present (nullable).
 - `intent` — echo of how the query was parsed (city, date/time, category).
   The fastest way to explain a bad list is a wrong `city` or
   `target_datetime` here.


### PR DESCRIPTION
Documents the `short_list_reason` response field that shipped in our tracker and deployed to prod today (closes the loop on our tracker).

- Response example: `"short_list_reason": null` added.
- "Reading the honesty signals": new bullet — `thin_pool` (market is genuinely thin; always co-occurs with `degraded: true`/`few_results`; widen or accept) vs `curated` (full pool, the ranker deliberately picked fewer — a good sign, `degraded` stays `false`) vs `null` (full list). Field is required-and-nullable, always present.
- AGENTS.md compact shape updated to match.
- Version 5.3.0 → 5.3.1.

Baseline for this addition was recorded by the 5.3.0 verification run itself: the test agent listed "can't tell the user we got 2 instead of the usual 4 / can't distinguish thin market from curation" among its unknowns — this is that answer, now that the API provides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
