### PR TITLE
docs+manifest: Cowork install path, and declare components before install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "placecall",
       "displayName": "PlaceCall",
       "source": "./",
-      "description": "PlaceCall — AI phone calls: book, confirm, reach any business.",
+      "description": "PlaceCall — AI phone calls: book, confirm, reach any business. Places real outbound calls through one REST API and returns a structured outcome plus a full transcript. Needs a free API key: https://api.voygr.tech/checkout",
       "version": "6.0.0",
       "author": {
         "name": "VOYGR",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,30 @@
   "plugins": [
     {
       "name": "placecall",
+      "displayName": "PlaceCall",
       "source": "./",
-      "description": "PlaceCall — AI phone calls: book, confirm, reach any business."
+      "description": "PlaceCall — AI phone calls: book, confirm, reach any business.",
+      "version": "6.0.0",
+      "author": {
+        "name": "VOYGR",
+        "url": "https://voygr.tech"
+      },
+      "homepage": "https://github.com/voygr-tech/placecall",
+      "repository": "https://github.com/voygr-tech/placecall",
+      "license": "MIT",
+      "keywords": [
+        "phone",
+        "calls",
+        "voice",
+        "telephony",
+        "booking",
+        "reservations",
+        "appointments"
+      ],
+      "category": "productivity",
+      "skills": [
+        "./skills/call"
+      ]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "placecall",
-  "description": "PlaceCall — AI phone calls: book, confirm, reach any business. Places real outbound calls through one REST API and returns a structured outcome plus a full transcript.",
+  "description": "PlaceCall — AI phone calls: book, confirm, reach any business. Places real outbound calls through one REST API and returns a structured outcome plus a full transcript. Needs a free API key: https://api.voygr.tech/checkout",
   "version": "6.0.0",
   "author": {
     "name": "VOYGR",

--- a/README.md
+++ b/README.md
@@ -25,8 +25,23 @@ Two commands, no shell, no git — and it **auto-updates** from this repo:
 /plugin marketplace add voygr-tech/placecall
 /plugin install placecall@placecall
 ```
-The skill then answers to `/placecall:call`, and Claude reaches for it on its own
-whenever you ask to call someone.
+Claude Code asks where to install it — choose **user scope** ("Install for you")
+unless you specifically want it confined to one repository. The skill then answers
+to `/placecall:call`, and Claude reaches for it on its own whenever you ask to
+call someone.
+
+### Cowork
+Same marketplace, no terminal:
+
+1. **Customize** → **Plugins** → **Add marketplace**
+2. Enter `voygr-tech/placecall`
+3. Click **Install** on the PlaceCall plugin
+
+You then add your key the same way as everywhere else (next section).
+
+> **Not claude.ai Chat.** Plugins reach Claude Code and Cowork. They do not add
+> anything to Claude chat conversations — the API is still just HTTP, so any agent
+> with a shell can use it (see "Any agent / plain shell" below).
 
 ### Claude Code, without the plugin
 ```sh


### PR DESCRIPTION
Two gaps found while running the clean-machine install. Both are in the install path a stranger actually walks.

## 1. The trust screen showed nothing to base trust on

Installing printed only:

> **Will install:** · Components will be discovered at installation

directly beneath the warning telling the user to make sure they trust the plugin.

**Why:** that screen reads the **marketplace entry**, not the plugin's own `plugin.json`. This is not a timing problem — `marketplace add` clones the repo, so `plugin.json` (which already declared `skills: ["./skills/call"]`) was on disk and went unused. Component visibility before install comes from the marketplace entry or not at all.

**The trust argument is stronger than "1 skill".** The components that execute code are `mcpServers` and `hooks`, and we ship neither. But because we declared nothing, that screen looked *identical* to a plugin installing an MCP server and a `PostToolUse` hook. Declaring `skills` — and only `skills` — is what turns "trust us" into something a person can check.

Added alongside it the provenance someone would actually judge on: `displayName`, `version`, `author`, `homepage`, `repository`, `license`, `keywords`, `category`.

**Two things a reviewer should check:**

- `strict` is deliberately left at its default (`true`) so the marketplace entry **supplements** `plugin.json`. Setting `strict: false` would make the entry the complete definition, which conflicts with the `plugin.json` we already ship and fails to load.
- `version` now appears in **both** manifests and can drift. That's anticipated rather than sloppy: `claude plugin tag` creates a release tag *"validating that plugin.json and any enclosing marketplace entry agree"*. Worth wiring into the release step — I ran it `--dry-run` and it refused on a dirty tree, so the agreement check itself is still unproven.

## 2. The README had no Cowork section at all

Half of #553's acceptance is "Cowork: add marketplace by owner/repo → install → skill visible and invocable", and there was nothing in the README describing that path, so it could not be verified. Added the click path (**Customize → Plugins → Add marketplace → `voygr-tech/placecall` → Install**).

It also carries an explicit **"Not claude.ai Chat"** note. Plugins reach Claude Code and Cowork; the connector rail is a different door, and implying Chat support here would be a false promise on the page people read first.

## Also: the install-scope prompt

The README presented the install as two pasteable commands, but Claude Code asks **user / project / local** in between — a decision a stranger had to resolve with no guidance. Someone who picks "local" gets a plugin that silently stops working in every other directory and no way to diagnose it. Now documented, recommending user scope.

## Verification

`claude plugin validate --strict` passes on both manifests.

⚠️ **The one thing I could not verify:** that the Discover screen now lists the skill. The CLI has no way to render that view — `claude plugin details` only works post-install. The mechanism is established from the clone-timing evidence above plus the marketplace schema docs, not from watching the screen change. **To confirm after merge:** `/plugin marketplace update placecall`, then open Discover and check it lists the skill instead of "discovered at installation."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cm1gGa85tG6R5SBpwbGwe
