### PR TITLE
docs: drop em dashes from everything a person reads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "placecall",
-  "description": "VOYGR's marketplace for PlaceCall — give your agent a phone.",
+  "description": "VOYGR's marketplace for PlaceCall. Give your agent a phone.",
   "owner": {
     "name": "VOYGR",
     "url": "https://voygr.tech"
@@ -10,7 +10,7 @@
       "name": "placecall",
       "displayName": "PlaceCall",
       "source": "./",
-      "description": "PlaceCall — AI phone calls: book, confirm, reach any business. Places real outbound calls through one REST API and returns a structured outcome plus a full transcript. Needs a free API key: https://api.voygr.tech/checkout",
+      "description": "PlaceCall makes AI phone calls that book, confirm, and reach any business. One REST API places a real outbound call and returns a structured outcome plus a full transcript. Free API key at https://api.voygr.tech/checkout",
       "version": "6.0.0",
       "author": {
         "name": "VOYGR",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "placecall",
-  "description": "PlaceCall — AI phone calls: book, confirm, reach any business. Places real outbound calls through one REST API and returns a structured outcome plus a full transcript. Needs a free API key: https://api.voygr.tech/checkout",
+  "description": "PlaceCall makes AI phone calls that book, confirm, and reach any business. One REST API places a real outbound call and returns a structured outcome plus a full transcript. Free API key at https://api.voygr.tech/checkout",
   "version": "6.0.0",
   "author": {
     "name": "VOYGR",

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# PlaceCall — give your agent a phone ☎️
+# PlaceCall - give your agent a phone ☎️
 
 **Two API endpoints: one finds who to call, one places a real phone call.** Hand
 `POST /calls` a number and a plain-English task; PlaceCall dials it, talks to
 whoever answers, works through menus/hold, and returns a structured result + full
 transcript. No number yet? `POST /v1/places/suggest` turns "book a romantic
-restaurant in Chicago Saturday 8pm" into ready-to-dial place cards — phone,
-reasoning, and a ready-made call brief — free of charge. It's how your agent
-reaches the ~80% of businesses that have a phone, not an API — inquiries, booking,
+restaurant in Chicago Saturday 8pm" into ready-to-dial place cards - phone,
+reasoning, and a ready-made call brief - free of charge. It's how your agent
+reaches the ~80% of businesses that have a phone, not an API - inquiries, booking,
 lead-gen, appointment-setting.
 
 ```sh
@@ -16,16 +16,16 @@ curl -s -X POST https://api.voygr.tech/calls \
 ```
 
 ## Install
-Installing the skill needs **no key** — it just teaches your agent how to call the
+Installing the skill needs **no key** - it just teaches your agent how to call the
 API. You add your key separately (next section) before placing real calls.
 
 ### Claude Code (recommended)
-Two commands, no shell, no git — and it **auto-updates** from this repo:
+Two commands, no shell, no git - and it **auto-updates** from this repo:
 ```
 /plugin marketplace add voygr-tech/placecall
 /plugin install placecall@placecall
 ```
-Claude Code asks where to install it — choose **user scope** ("Install for you")
+Claude Code asks where to install it - choose **user scope** ("Install for you")
 unless you specifically want it confined to one repository. The skill then answers
 to `/placecall:call`, and Claude reaches for it on its own whenever you ask to
 call someone.
@@ -40,7 +40,7 @@ Same marketplace, no terminal:
 You then add your key the same way as everywhere else (next section).
 
 > **Not claude.ai Chat.** Plugins reach Claude Code and Cowork. They do not add
-> anything to Claude chat conversations — the API is still just HTTP, so any agent
+> anything to Claude chat conversations - the API is still just HTTP, so any agent
 > with a shell can use it (see "Any agent / plain shell" below).
 
 ### Claude Code, without the plugin
@@ -48,15 +48,15 @@ You then add your key the same way as everywhere else (next section).
 git clone https://github.com/voygr-tech/placecall && cd placecall
 ./install.sh     # copies skills/call/SKILL.md -> ~/.claude/skills/placecall/
 ```
-`install.sh` is a tiny convenience script — it **only** copies
+`install.sh` is a tiny convenience script - it **only** copies
 `skills/call/SKILL.md` into your skills dir (no network, no other side
 effects); you can also copy it by hand. Then start a **fresh** Claude Code session
-(skills load at startup). Note that a copy never updates itself — if you want new
+(skills load at startup). Note that a copy never updates itself - if you want new
 skills and fixes as we ship them, prefer the plugin above.
 
 ### Codex
 Use the Codex skill installer, pointing at the skill subdirectory. Pass `--name`
-explicitly — the path would otherwise name the skill `call`, which is generic
+explicitly - the path would otherwise name the skill `call`, which is generic
 enough to collide with anything else you have installed:
 ```sh
 python3 install-skill-from-github.py \
@@ -65,23 +65,23 @@ python3 install-skill-from-github.py \
   --name placecall
 ```
 Codex prefers its installer over running third-party scripts, so **don't** run
-`install.sh` on Codex — use the command above. (Alternatively, paste this repo's
+`install.sh` on Codex - use the command above. (Alternatively, paste this repo's
 [`AGENTS.md`](./AGENTS.md) into your project's `AGENTS.md`.)
 
 ### Any agent / plain shell
-No install needed — the API is just HTTP. `skills/call/SKILL.md` is the full
+No install needed - the API is just HTTP. `skills/call/SKILL.md` is the full
 reference; a model with a shell tool can place calls straight from it.
 
 ## Get a key (self-serve) and set it
 Installing the skill does **not** need a key; **placing calls does.** Keys are
-**self-serve** — no need to contact anyone:
+**self-serve** - no need to contact anyone:
 
 1. Open <https://api.voygr.tech/checkout> and click **"Get free API key"**
    (name + email), or `curl -s -X POST https://api.voygr.tech/signup -H
    "Content-Type: application/json" -d '{"name":"<you>","email":"<you@example.com>"}'`.
 2. The key arrives **by email** (it is never shown in the browser or API
    response). Free tier: **2,500 credits** (250 successful calls) with a
-   25-calls/day cap. **Any credit purchase lifts the cap to 5,000/day** —
+   25-calls/day cap. **Any credit purchase lifts the cap to 5,000/day** -
    once you've paid, credits are your only practical limit.
 3. Lost the key? <https://api.voygr.tech/recover> emails you a new one.
 4. Need more credits? Top up on the same <https://api.voygr.tech/checkout>
@@ -89,12 +89,12 @@ Installing the skill does **not** need a key; **placing calls does.** Keys are
 
 Then set the key in your shell:
 
-**Quick way** — just export it for the current session:
+**Quick way** - just export it for the current session:
 ```sh
 export PLACECALL_API_KEY="<your key>"
 ```
 
-**Nicer way** — save it once (no echo to screen, `600` perms) and load it per session:
+**Nicer way** - save it once (no echo to screen, `600` perms) and load it per session:
 ```sh
 mkdir -p ~/.codex
 read -rsp "PLACECALL_API_KEY: " KEY; echo
@@ -109,7 +109,7 @@ source ~/.codex/placecall.env
 ```sh
 curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/users/me
 ```
-Never commit `~/.codex/placecall.env` or paste the key into chat — keep it in the
+Never commit `~/.codex/placecall.env` or paste the key into chat - keep it in the
 env var / the `600` file above.
 
 ## Installed this before August 2026?
@@ -117,7 +117,7 @@ This project was called **Callwright** until 2026-08, and the repo lived at
 `voygr-tech/callwright-skill`. Two things to know:
 
 - **Your existing setup keeps working.** `install.sh` copies the skill rather than
-  linking it, so an older copy is frozen at whatever it was when you installed —
+  linking it, so an older copy is frozen at whatever it was when you installed -
   the rename cannot break it. It also means it will never pick up new skills or
   fixes, which is the reason to migrate.
 - **To migrate, delete the old copy first.** It is still a working phone skill, so
@@ -127,14 +127,14 @@ This project was called **Callwright** until 2026-08, and the repo lived at
   rm -rf ~/.claude/skills/callwright ~/.claude/skills/callwright-skill
   ```
   Then install the plugin above, and re-export your key under its new name:
-  `PLACECALL_API_KEY`. The key itself is unchanged — only the variable is renamed,
+  `PLACECALL_API_KEY`. The key itself is unchanged - only the variable is renamed,
   so no need to reissue anything.
 
 If you previously installed a phone-call skill from someone else (e.g.
 `ai-call-agent`), remove or disable that too, for the same reason.
 
 ## The one rule
-**Everything goes in the `brief`** — the bot reads only your brief. Put every detail
+**Everything goes in the `brief`** - the bot reads only your brief. Put every detail
 in it (what to ask, who you're calling for, names/dates/party size/callback number,
 how to wrap up). One endpoint, describe the task, done.
 
@@ -142,18 +142,18 @@ how to wrap up). One endpoint, describe the task, done.
 - **Only successful calls are billed** (10 credits per `success_*` outcome;
   voicemails/hangups/no-answers are free). Each call takes a refundable
   **30-credit hold** at dial time (3× the charge, settled down to 10 on
-  success) — under 30 available and `POST /calls` returns `402` even with a
+  success) - under 30 available and `POST /calls` returns `402` even with a
   non-zero balance (`GET /users/me` for your balance; top-ups are self-serve
   at <https://api.voygr.tech/checkout>).
 - After a call `completed`, the outcome/transcript can populate a moment
-  *after* the status flips — poll `GET /calls/{id}` until `outcome_type` is
+  *after* the status flips - poll `GET /calls/{id}` until `outcome_type` is
   non-null.
 - 13 language codes accepted (`en`, `es`, `fr`, `de`, `hi`, `ru`, `pt`, `ja`,
   `it`, `nl`, `sr`, `tr`, `pl`) plus `auto` (the default, resolves to `en`).
   `en` is the most reliable; non-English is best-effort.
-- Only call numbers you're authorized to — real calls ring real phones.
+- Only call numbers you're authorized to - real calls ring real phones.
   US destinations only; every call discloses it's a recorded AI call.
 
 **Full reference:** [`skills/call/SKILL.md`](./skills/call/SKILL.md) (Claude Code) · [`AGENTS.md`](./AGENTS.md) (Codex).
 
-**Live API docs:** <https://api.voygr.tech/docs> — log in with your PlaceCall key (the same one you set as `PLACECALL_API_KEY`).
+**Live API docs:** <https://api.voygr.tech/docs> - log in with your PlaceCall key (the same one you set as `PLACECALL_API_KEY`).

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# PlaceCall — legacy convenience installer for Claude Code.
+# PlaceCall - legacy convenience installer for Claude Code.
 #
 # PREFER THE PLUGIN. It auto-updates from this repo; this script does not:
 #   /plugin marketplace add voygr-tech/placecall
 #   /plugin install placecall@placecall
 #
 # This script ONLY copies skills/call/SKILL.md into your Claude Code skills dir.
-# No network calls, no other side effects — you can also copy the file by hand.
-# (Codex users: don't run this — use the Codex skill installer, see README.)
+# No network calls, no other side effects - you can also copy the file by hand.
+# (Codex users: don't run this - use the Codex skill installer, see README.)
 set -e
 SRC="$(cd "$(dirname "$0")" && pwd)"
 DEST="${HOME}/.claude/skills/placecall"
@@ -34,4 +34,4 @@ fi
 echo "Next:"
 echo "  1) export PLACECALL_API_KEY=<your key>   (free self-serve key: https://api.voygr.tech/checkout)"
 echo "  2) start a fresh Claude Code session (skills load at startup)"
-echo "  3) ask it to call a number — it uses the skill automatically"
+echo "  3) ask it to call a number - it uses the skill automatically"


### PR DESCRIPTION
Em dashes look terrible (decided 2026-08-26). Replaced with the spaced hyphen he uses himself, or restructured where a hyphen read badly.

There were **149** in the repo. This removes the **32** in files a human looks at:

| File | Removed |
|---|---|
| `README.md` | 25 |
| `install.sh` | 4 |
| `.claude-plugin/plugin.json` | 1 |
| `.claude-plugin/marketplace.json` | 2 |

The two manifest descriptions were **rewritten by hand**, not find-and-replaced, because that is the copy shown in the plugin manager. They now read:

> PlaceCall makes AI phone calls that book, confirm, and reach any business. One REST API places a real outbound call and returns a structured outcome plus a full transcript. Free API key at https://api.voygr.tech/checkout

Kept byte-identical across `plugin.json` and the marketplace entry, since `claude plugin tag` validates that the two agree, and since the two are read by different panes: the Installed/Marketplaces pane renders `plugin.json`, while the Discover pane renders the marketplace entry. Letting them drift would show a user different copy depending on which tab they opened.

## Deliberately not touched

`skills/call/SKILL.md` (95) and `AGENTS.md` (22). Those are instruction text a model reads, not copy a person looks at, and a mechanical sweep across 117 sites in the file that defines the API contract risks garbling an instruction for no visual gain. Say the word and they go too.

## One tradeoff worth knowing rather than burying

The frozen listing title in our tracker contains an em dash, and that exact string is already published and **immutable** in the npm descriptions for `@voygr/placecall@0.0.1` and `placecall@0.0.1`. So the plugin copy and the npm copy no longer match word for word. Given #680 is about consistent claims across indexed surfaces, that is a real if minor cost, and the fix would be republishing npm at a new version rather than reinstating the dash here.

## Verified

`claude plugin validate --strict` passes. `bash -n install.sh` clean. Descriptions confirmed identical across both manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cm1gGa85tG6R5SBpwbGwe
