### PR TITLE
fix: Codex names the skill from frontmatter, plus dedupe Cowork

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "placecall",
-  "description": "VOYGR's marketplace for PlaceCall — give your agent a phone.",
+  "description": "VOYGR's marketplace for PlaceCall. Give your agent a phone.",
   "owner": {
     "name": "VOYGR",
     "url": "https://voygr.tech"
@@ -10,7 +10,7 @@
       "name": "placecall",
       "displayName": "PlaceCall",
       "source": "./",
-      "description": "PlaceCall — AI phone calls: book, confirm, reach any business. Places real outbound calls through one REST API and returns a structured outcome plus a full transcript. Needs a free API key: https://api.voygr.tech/checkout",
+      "description": "PlaceCall makes AI phone calls that book, confirm, and reach any business. One REST API places a real outbound call and returns a structured outcome plus a full transcript. Free API key at https://api.voygr.tech/checkout",
       "version": "6.0.0",
       "author": {
         "name": "VOYGR",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "placecall",
-  "description": "PlaceCall — AI phone calls: book, confirm, reach any business. Places real outbound calls through one REST API and returns a structured outcome plus a full transcript. Needs a free API key: https://api.voygr.tech/checkout",
+  "description": "PlaceCall makes AI phone calls that book, confirm, and reach any business. One REST API places a real outbound call and returns a structured outcome plus a full transcript. Free API key at https://api.voygr.tech/checkout",
   "version": "6.0.0",
   "author": {
     "name": "VOYGR",

--- a/COWORK-TEST.md
+++ b/COWORK-TEST.md
@@ -1,0 +1,101 @@
+# Cowork install test: PlaceCall
+
+**What we need from you:** confirm a person can install PlaceCall in Cowork and place one real phone call, following only these steps. Takes about 10 minutes. The last box on voygr-tech/callwright#553.
+
+**Why you specifically:** you already have the old Callwright skill on your Cowork, which makes you the realistic case. Most of this doc is about removing it first, because if it stays, we cannot tell which one placed the call.
+
+---
+
+## Step 0: remove the old skill (do not skip)
+
+The project was renamed from Callwright to PlaceCall. Your old copy is still a working phone skill, so leaving it in place gives Cowork two of them and the routing between them is ambiguous. Worse, a call could succeed through the old one and we would wrongly conclude the new install works.
+
+The old install may be under any of these names. Ask Cowork:
+
+> Do I have any phone-calling skill installed? Check `~/.claude/skills/` for directories named `callwright`, `callwright-skill`, `ai-call-agent`, or anything else that places phone calls. List what you find and show me the `name:` line from each SKILL.md.
+
+If it finds anything, remove it:
+
+```sh
+rm -rf ~/.claude/skills/callwright ~/.claude/skills/callwright-skill ~/.claude/skills/ai-call-agent
+```
+
+Also unset any old key, which will not work against the new API path:
+
+```sh
+unset CALLWRIGHT_API_KEY CALLWRIGHT_SKILL_API_KEY AI_CALL_AGENT_API_KEY_TEST
+```
+
+If any of those are exported from `~/.bashrc`, `~/.zshrc` or `~/.profile`, comment them out too, then restart Cowork.
+
+**Please tell us what you found here**, even if it was nothing. On Ilya's laptop the contaminating skill turned out to be named `ai-call-agent` and pointed at a completely different backend, which we only discovered by accident.
+
+## Step 1: baseline reading
+
+Restart Cowork, then ask it, in a conversation with nothing else in it:
+
+> What skills do you have? Can you place a phone call?
+
+**Copy the answer verbatim and send it to us.** We expect it to say it cannot place calls. If it says it can, stop: something is still installed and step 0 was incomplete.
+
+## Step 2: install
+
+In Cowork:
+
+1. **Customize** > **Plugins** > **Add marketplace**
+2. Enter `voygr-tech/placecall`
+3. Click **Install** on the PlaceCall plugin
+4. If asked where to install, choose the **user** or **for you** option, not the repository or project option
+
+**If the menu labels differ from the above, tell us.** Nobody on our side has run this in Cowork; those labels come from our design notes, not from someone's screen. Getting them wrong in the README is itself a finding.
+
+Before you click Install, the details screen should show a **Will install** section naming one skill. **Screenshot that screen.** It is the only place we can confirm the plugin declares what it contains.
+
+## Step 3: confirm the install took
+
+Ask the exact same question as step 1:
+
+> What skills do you have? Can you place a phone call?
+
+Send us this answer too. It should now say it can, name PlaceCall, and tell you it needs an API key. If it needs a restart before working, tell us, because that differs from Claude Code where it activates immediately.
+
+## Step 4: get a key
+
+1. Open <https://api.voygr.tech/checkout>
+2. Enter your name and **your own email**, click **Get free API key**
+3. The key arrives by email. It is never shown in the browser.
+4. Set it in your terminal, then restart Cowork:
+
+```sh
+export PLACECALL_API_KEY="<the key from the email>"
+```
+
+If that does not stick, the durable option, which the skill checks automatically:
+
+```sh
+mkdir -p ~/.codex
+read -rsp "PLACECALL_API_KEY: " KEY; echo
+printf 'export PLACECALL_API_KEY=%q\n' "$KEY" > ~/.codex/placecall.env
+chmod 600 ~/.codex/placecall.env
+unset KEY
+```
+
+**Do not paste the key into a chat message.** Use the terminal. A key pasted into a conversation ends up in that conversation's transcript in plaintext.
+
+## Step 5: place one real call
+
+Ask in plain English, the way you actually would:
+
+> call [some business] at [phone number] and ask what time they close today
+
+**This rings a real phone**, so pick somewhere you do not mind calling. US numbers only. Every call announces itself as a recorded AI call. A successful call costs 10 credits and you start with 2,500.
+
+## What to send back
+
+- What step 0 found, even if nothing
+- The step 1 and step 3 answers, verbatim
+- The screenshot of the **Will install** screen
+- The **call ID** and outcome
+- **Anything you had to guess at.** This is the most valuable part. If a step was unclear, or a label was wrong, or you had to figure something out that this doc did not tell you, write that down instead of solving it silently. The point is to find where a stranger gets stuck, and you only get one chance to read this cold.
+
+Questions to ilya@voygr.tech.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# PlaceCall — give your agent a phone ☎️
+# PlaceCall - give your agent a phone ☎️
 
 **Two API endpoints: one finds who to call, one places a real phone call.** Hand
 `POST /calls` a number and a plain-English task; PlaceCall dials it, talks to
 whoever answers, works through menus/hold, and returns a structured result + full
 transcript. No number yet? `POST /v1/places/suggest` turns "book a romantic
-restaurant in Chicago Saturday 8pm" into ready-to-dial place cards — phone,
-reasoning, and a ready-made call brief — free of charge. It's how your agent
-reaches the ~80% of businesses that have a phone, not an API — inquiries, booking,
+restaurant in Chicago Saturday 8pm" into ready-to-dial place cards - phone,
+reasoning, and a ready-made call brief - free of charge. It's how your agent
+reaches the ~80% of businesses that have a phone, not an API - inquiries, booking,
 lead-gen, appointment-setting.
 
 ```sh
@@ -16,77 +16,89 @@ curl -s -X POST https://api.voygr.tech/calls \
 ```
 
 ## Install
-Installing the skill needs **no key** — it just teaches your agent how to call the
+Installing the skill needs **no key** - it just teaches your agent how to call the
 API. You add your key separately (next section) before placing real calls.
 
 ### Claude Code (recommended)
-Two commands, no shell, no git — and it **auto-updates** from this repo:
+Two commands, no shell, no git - and it **auto-updates** from this repo:
 ```
 /plugin marketplace add voygr-tech/placecall
 /plugin install placecall@placecall
 ```
-Claude Code asks where to install it — choose **user scope** ("Install for you")
+Claude Code asks where to install it - choose **user scope** ("Install for you")
 unless you specifically want it confined to one repository. The skill then answers
 to `/placecall:call`, and Claude reaches for it on its own whenever you ask to
 call someone.
-
-### Cowork
-Same marketplace, no terminal:
-
-1. **Customize** → **Plugins** → **Add marketplace**
-2. Enter `voygr-tech/placecall`
-3. Click **Install** on the PlaceCall plugin
-
-You then add your key the same way as everywhere else (next section).
-
-> **Not claude.ai Chat.** Plugins reach Claude Code and Cowork. They do not add
-> anything to Claude chat conversations — the API is still just HTTP, so any agent
-> with a shell can use it (see "Any agent / plain shell" below).
 
 ### Claude Code, without the plugin
 ```sh
 git clone https://github.com/voygr-tech/placecall && cd placecall
 ./install.sh     # copies skills/call/SKILL.md -> ~/.claude/skills/placecall/
 ```
-`install.sh` is a tiny convenience script — it **only** copies
+`install.sh` is a tiny convenience script - it **only** copies
 `skills/call/SKILL.md` into your skills dir (no network, no other side
 effects); you can also copy it by hand. Then start a **fresh** Claude Code session
-(skills load at startup). Note that a copy never updates itself — if you want new
+(skills load at startup). Note that a copy never updates itself - if you want new
 skills and fixes as we ship them, prefer the plugin above.
 
-### Claude Cowork
-Same package as the Claude Code plugin, no terminal at all: open
-**Customize > Plugins > Add marketplace**, paste `voygr-tech/placecall`, then
-click **Install** on the PlaceCall card. Auto-updates from this repo, like the
-Code plugin.
+### Cowork
+Same package as the Claude Code plugin, no terminal at all:
+
+1. **Customize** > **Plugins** > **Add marketplace**
+2. Paste `voygr-tech/placecall`
+3. Click **Install** on the PlaceCall card
+
+Auto-updates from this repo, like the Code plugin. Add your key the same way as
+everywhere else (next section).
+
+> **Not claude.ai Chat.** Plugins reach Claude Code and Cowork. They do not add
+> anything to Claude chat conversations. The API is still just HTTP, so any agent
+> with a shell can use it (see "Any agent / plain shell" below).
 
 ### Codex
-One line, typed inside Codex — `$skill-installer` is a system skill bundled
-with Codex (v0.130.0+), nothing to set up first. Pass `--name`: the folder
-would otherwise name the skill `call`, which is generic enough to collide with
-anything else you have installed:
+**Type this inside Codex, not in your shell.** `$skill-installer` is a system
+skill bundled with Codex, so there is nothing to set up first:
+
 ```
-$skill-installer install https://github.com/voygr-tech/placecall/tree/main/skills/call --name placecall
+$skill-installer install the skill at https://github.com/voygr-tech/placecall/tree/main/skills/call and name it placecall
 ```
-Then restart Codex (skills load at startup) and check with `$skill-installer
-list`. **Don't** run `install.sh` on Codex. On older Codex versions without
-`$skill-installer`, or as an alternative, paste this repo's
-[`AGENTS.md`](./AGENTS.md) into your project's `AGENTS.md`.
+
+It is a skill rather than a command, so plain English works and is what it
+expects. It runs the install for you and reports where the skill landed. **No
+restart needed**, it is available on your next turn, and it answers to
+`$placecall`.
+
+If the phrasing above is not understood, this is the script it runs, and you can
+run it yourself from a normal shell:
+
+```sh
+python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --url https://github.com/voygr-tech/placecall/tree/main/skills/call \
+  --name placecall
+```
+
+Two things worth knowing. The installer refuses to overwrite, so if you already
+have a `placecall` (or older `callwright`) skill in `~/.codex/skills`, delete it
+first or the install aborts. And **don't** run `install.sh` on Codex, that is the
+Claude Code path.
+
+On older Codex without `$skill-installer`, or as an alternative on any Codex,
+paste this repo's [`AGENTS.md`](./AGENTS.md) into your project's `AGENTS.md`.
 
 ### Any agent / plain shell
-No install needed — the API is just HTTP. `skills/call/SKILL.md` is the full
+No install needed - the API is just HTTP. `skills/call/SKILL.md` is the full
 reference; a model with a shell tool can place calls straight from it.
 
 ## Get a key (self-serve) and set it
 Installing the skill does **not** need a key; **placing calls does.** Keys are
-**self-serve** — no need to contact anyone:
+**self-serve** - no need to contact anyone:
 
 1. Open <https://api.voygr.tech/checkout> and click **"Get free API key"**
    (name + email), or `curl -s -X POST https://api.voygr.tech/signup -H
    "Content-Type: application/json" -d '{"name":"<you>","email":"<you@example.com>"}'`.
 2. The key arrives **by email** (it is never shown in the browser or API
    response). Free tier: **2,500 credits** (250 successful calls) with a
-   25-calls/day cap. **Any credit purchase lifts the cap to 5,000/day** —
+   25-calls/day cap. **Any credit purchase lifts the cap to 5,000/day** -
    once you've paid, credits are your only practical limit.
 3. Lost the key? <https://api.voygr.tech/recover> emails you a new one.
 4. Need more credits? Top up on the same <https://api.voygr.tech/checkout>
@@ -94,12 +106,12 @@ Installing the skill does **not** need a key; **placing calls does.** Keys are
 
 Then set the key in your shell:
 
-**Quick way** — just export it for the current session:
+**Quick way** - just export it for the current session:
 ```sh
 export PLACECALL_API_KEY="<your key>"
 ```
 
-**Nicer way** — save it once (no echo to screen, `600` perms) and load it per session:
+**Nicer way** - save it once (no echo to screen, `600` perms) and load it per session:
 ```sh
 mkdir -p ~/.codex
 read -rsp "PLACECALL_API_KEY: " KEY; echo
@@ -114,7 +126,7 @@ source ~/.codex/placecall.env
 ```sh
 curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/users/me
 ```
-Never commit `~/.codex/placecall.env` or paste the key into chat — keep it in the
+Never commit `~/.codex/placecall.env` or paste the key into chat - keep it in the
 env var / the `600` file above.
 
 ## Installed this before August 2026?
@@ -122,7 +134,7 @@ This project was called **Callwright** until 2026-08, and the repo lived at
 `voygr-tech/callwright-skill`. Two things to know:
 
 - **Your existing setup keeps working.** `install.sh` copies the skill rather than
-  linking it, so an older copy is frozen at whatever it was when you installed —
+  linking it, so an older copy is frozen at whatever it was when you installed -
   the rename cannot break it. It also means it will never pick up new skills or
   fixes, which is the reason to migrate.
 - **To migrate, delete the old copy first.** It is still a working phone skill, so
@@ -132,14 +144,14 @@ This project was called **Callwright** until 2026-08, and the repo lived at
   rm -rf ~/.claude/skills/callwright ~/.claude/skills/callwright-skill
   ```
   Then install the plugin above, and re-export your key under its new name:
-  `PLACECALL_API_KEY`. The key itself is unchanged — only the variable is renamed,
+  `PLACECALL_API_KEY`. The key itself is unchanged - only the variable is renamed,
   so no need to reissue anything.
 
 If you previously installed a phone-call skill from someone else (e.g.
 `ai-call-agent`), remove or disable that too, for the same reason.
 
 ## The one rule
-**Everything goes in the `brief`** — the bot reads only your brief. Put every detail
+**Everything goes in the `brief`** - the bot reads only your brief. Put every detail
 in it (what to ask, who you're calling for, names/dates/party size/callback number,
 how to wrap up). One endpoint, describe the task, done.
 
@@ -147,18 +159,18 @@ how to wrap up). One endpoint, describe the task, done.
 - **Only successful calls are billed** (10 credits per `success_*` outcome;
   voicemails/hangups/no-answers are free). Each call takes a refundable
   **30-credit hold** at dial time (3× the charge, settled down to 10 on
-  success) — under 30 available and `POST /calls` returns `402` even with a
+  success) - under 30 available and `POST /calls` returns `402` even with a
   non-zero balance (`GET /users/me` for your balance; top-ups are self-serve
   at <https://api.voygr.tech/checkout>).
 - After a call `completed`, the outcome/transcript can populate a moment
-  *after* the status flips — poll `GET /calls/{id}` until `outcome_type` is
+  *after* the status flips - poll `GET /calls/{id}` until `outcome_type` is
   non-null.
 - 13 language codes accepted (`en`, `es`, `fr`, `de`, `hi`, `ru`, `pt`, `ja`,
   `it`, `nl`, `sr`, `tr`, `pl`) plus `auto` (the default, resolves to `en`).
   `en` is the most reliable; non-English is best-effort.
-- Only call numbers you're authorized to — real calls ring real phones.
+- Only call numbers you're authorized to - real calls ring real phones.
   US destinations only; every call discloses it's a recorded AI call.
 
 **Full reference:** [`skills/call/SKILL.md`](./skills/call/SKILL.md) (Claude Code) · [`AGENTS.md`](./AGENTS.md) (Codex).
 
-**Live API docs:** <https://api.voygr.tech/docs> — log in with your PlaceCall key (the same one you set as `PLACECALL_API_KEY`).
+**Live API docs:** <https://api.voygr.tech/docs> - log in with your PlaceCall key (the same one you set as `PLACECALL_API_KEY`).

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# PlaceCall — legacy convenience installer for Claude Code.
+# PlaceCall - legacy convenience installer for Claude Code.
 #
 # PREFER THE PLUGIN. It auto-updates from this repo; this script does not:
 #   /plugin marketplace add voygr-tech/placecall
 #   /plugin install placecall@placecall
 #
 # This script ONLY copies skills/call/SKILL.md into your Claude Code skills dir.
-# No network calls, no other side effects — you can also copy the file by hand.
-# (Codex users: don't run this — use the Codex skill installer, see README.)
+# No network calls, no other side effects - you can also copy the file by hand.
+# (Codex users: don't run this - use the Codex skill installer, see README.)
 set -e
 SRC="$(cd "$(dirname "$0")" && pwd)"
 DEST="${HOME}/.claude/skills/placecall"
@@ -34,4 +34,4 @@ fi
 echo "Next:"
 echo "  1) export PLACECALL_API_KEY=<your key>   (free self-serve key: https://api.voygr.tech/checkout)"
 echo "  2) start a fresh Claude Code session (skills load at startup)"
-echo "  3) ask it to call a number — it uses the skill automatically"
+echo "  3) ask it to call a number - it uses the skill automatically"

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: call
+name: placecall
 description: Use WHENEVER the user wants to make a phone call, call a number, ask a business something by phone, book or cancel a reservation, find a place or business to call when no phone number is at hand ("find me a florist and call them"), check a call's status/outcome, or answer a question the call bot asked mid-call. Places REAL outbound voice calls via the PlaceCall REST API and follows the call. Always consult this skill before saying you cannot make calls or find businesses to call.
 version: 6.0.0
 author: voygr-tech


### PR DESCRIPTION
Three fixes, all found by running the Codex install **live** on a clean machine.

## 1. The real bug: `--name` cannot do what we needed it to

`SKILL.md` frontmatter goes from `name: call` to `name: placecall`.

**Codex takes a skill's invocation name from the frontmatter and ignores both the install directory and `--name`. Claude Code does the exact opposite: the directory basename wins and frontmatter is ignored.** Both verified directly, the second with a probe skill whose two names deliberately disagreed.

So `--name placecall` renamed the directory on disk and nothing else. Codex answered as **`$call`**, the generic name that flag exists to prevent, and flagged the cause itself:

> Note: the source manifest internally declares `name: call`, while its installed directory is named `placecall`.

Setting the frontmatter fixes Codex and changes nothing on Claude Code, which still reads the `skills/call` directory and still gives `/placecall:call`, the form published in #596. Both rails end up correct precisely because each platform ignores the field the other one uses. That is luck rather than design, but it is bankable and worth writing down.

## 2. The README had two Cowork sections

#11 added `### Cowork` and #13 added `### Claude Cowork`. Git merged them cleanly because they never textually overlap, so **the duplicate shipped to main.** Kept one, and moved it after the two Claude Code sections so those sit together instead of being split apart.

## 3. The Codex section was inferred, not tested, and wrong three ways

#13's version was documentation-shaped but not documentation-sourced. Against the real `skills/.system/skill-installer/SKILL.md` in `openai/skills`, and against the live run:

| #13 said | Reality |
|---|---|
| `$skill-installer install <url> --name x` | No `install` subcommand. It is an LLM-mediated skill that runs helper scripts. |
| "Then restart Codex (skills load at startup)" | No restart. The skill says "available on your next turn". |
| "check with `$skill-installer list`" | Not a command. Listing goes through `scripts/list-skills.py`. |

The one-liner now in the README is **the exact text that worked**, in plain English, which is what an LLM-mediated skill is built for. The fallback is the literal script invocation we watched it run, rather than another guess:

```
python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py --url ... --name placecall
```

Two additions from the run. It now says explicitly that the line is **typed inside Codex, not in a shell**, because a fenced block starting with `$` reads as a shell prompt and a stranger pastes it into bash. And it warns that the installer **aborts rather than overwriting** an existing skill directory, which matters because every machine we have checked already had a stale copy.

## Also

Folds in the em-dash removal from #12, which #13 partially reverted. #12 can be closed as superseded by this branch; keeping them separate would have meant a conflict in the same README block.

## Verified

`claude plugin validate --strict` passes. `bash -n install.sh` clean. Manifest descriptions byte-identical across both files, since `claude plugin tag` checks they agree. Zero em dashes in the files a person reads. Exactly one Cowork section.

**Not verified:** that Codex now answers to `$placecall` rather than `$call`. That needs a reinstall after this merges, which is the remaining check on #840 along with the real call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cm1gGa85tG6R5SBpwbGwe
