### PR TITLE
fix: tell the agent where the key is, and stop the event poll timing out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ No phone number at hand ("find me a florist and call them")? Use
 - Key unset? Source it in the SAME command as the call:
   `. ~/.codex/placecall.env && curl ...` (an `export` does not carry between
   commands). No such file: send the user to /checkout. Never glob for `.env`
-  files — that is credential hunting and sandboxes refuse it.
+  files, which is credential hunting and sandboxes refuse it.
 - No key? Self-serve at <https://api.voygr.tech/checkout> ("Get free API key" —
   emailed, free tier: 2,500 credits, 25 calls/day). Recovery: `/recover`.
 - Check: `curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/users/me`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ No phone number at hand ("find me a florist and call them")? Use
 ## Connection
 - Base: `https://api.voygr.tech`
 - Auth: header `X-API-Key: $PLACECALL_API_KEY` on EVERY request. Never echo the key.
+- Key unset? Source it in the SAME command as the call:
+  `. ~/.codex/placecall.env && curl ...` (an `export` does not carry between
+  commands). No such file: send the user to /checkout. Never glob for `.env`
+  files — that is credential hunting and sandboxes refuse it.
 - No key? Self-serve at <https://api.voygr.tech/checkout> ("Get free API key" —
   emailed, free tier: 2,500 credits, 25 calls/day). Recovery: `/recover`.
 - Check: `curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/users/me`
@@ -74,7 +78,7 @@ QUERY_UNPARSEABLE / LOCATION_REQUIRED / NO_PLACES_FOUND · `429` (Retry-After) �
 `503 PLACE_SUGGESTIONS_DISABLED` · `504` (retry once).
 
 ## Follow the call (poll; don't hold the stream open)
-Poll `GET /calls/{id}/events?after_event_id=N` with `--max-time 5`, tracking the
+Poll `GET /calls/{id}/events?after_event_id=N` with `--max-time 20`, tracking the
 last `id:`. Use the `?after_event_id=` query param, NOT the `Last-Event-ID`
 header (the param wins and survives proxies that strip the header). On
 `event: ask_user` → answer promptly via `POST /calls/{id}/answer`

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -37,7 +37,7 @@ for you. Do NOT web-search for businesses; suggest is the discovery step.
   An `export` in one command does NOT carry to the next, because each command
   runs in its own shell. If that file does not exist, tell the user to get a
   key at <https://api.voygr.tech/checkout>. **Do NOT search the filesystem for
-  credential files** (`.env` globs and similar) — reading one path the user
+  credential files** (`.env` globs and similar). Reading one path the user
   told you about is fine, hunting for credentials is not, and agent sandboxes
   correctly refuse it.
 - **No key yet? Self-serve, no human in the loop:** open

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -32,6 +32,14 @@ for you. Do NOT web-search for businesses; suggest is the discovery step.
 - **Auth:** EVERY request sends the header `X-API-Key`, value = **your PlaceCall
   key**. Store it in the env var `PLACECALL_API_KEY`; NEVER print or echo the
   value — reference it as `$PLACECALL_API_KEY` in shell commands.
+- **If `PLACECALL_API_KEY` is unset**, source `~/.codex/placecall.env` in the
+  SAME shell command as the request: `. ~/.codex/placecall.env && curl ...`.
+  An `export` in one command does NOT carry to the next, because each command
+  runs in its own shell. If that file does not exist, tell the user to get a
+  key at <https://api.voygr.tech/checkout>. **Do NOT search the filesystem for
+  credential files** (`.env` globs and similar) — reading one path the user
+  told you about is fine, hunting for credentials is not, and agent sandboxes
+  correctly refuse it.
 - **No key yet? Self-serve, no human in the loop:** open
   <https://api.voygr.tech/checkout> and use **"Get free API key"** (name +
   email), or `POST /signup` with `{"name":"...","email":"..."}` — the key is
@@ -279,14 +287,14 @@ deployment) · `504 SUGGEST_DEADLINE_EXCEEDED` (retry once).
 Following the call is how the bot reaches YOU mid-call (`ask_user`) and how you
 learn the result. **Do NOT use a long-lived `curl -N` stream** — SSE lines get
 stuck in the pipe buffer. **Instead POLL** `/calls/{id}/events?after_event_id=N`
-with a short `--max-time`. Use the **`?after_event_id=` query param, NOT the
+with `--max-time 20` (5s times out mid-call and looks like a broken integration). Use the **`?after_event_id=` query param, NOT the
 `Last-Event-ID` header** (the query param wins and survives proxies that strip
 the header).
 
 ```sh
 ID=<call_id>; LAST=0; STOP=$(($(date +%s)+120))
 while [ "$(date +%s)" -lt "$STOP" ]; do
-  OUT=$(curl -s --max-time 5 -H "X-API-Key: $PLACECALL_API_KEY" \
+  OUT=$(curl -s --max-time 20 -H "X-API-Key: $PLACECALL_API_KEY" \
         "https://api.voygr.tech/calls/$ID/events?after_event_id=$LAST")
   [ -n "$OUT" ] && echo "$OUT"
   N=$(printf '%s' "$OUT" | sed -n 's/^id: //p' | tail -1); [ -n "$N" ] && LAST=$N


### PR DESCRIPTION
Both found by running the AGENTS.md fallback path on Codex item 4.

## 1. Neither doc told the agent where the key lives

The README recommends storing the key in a `600`-perm file at `~/.codex/placecall.env` as the durable option. **Neither `SKILL.md` nor `AGENTS.md` ever named that path.** So the path we recommend to humans was invisible to the agent, and on a `401` it had nowhere to look.

It then improvised a filesystem sweep for `.env` files, and Codex's safety layer refused:

> Automatic approval review denied (risk: high, authorization: low): After normal authentication failed, this searches local configuration files for a potentially usable API credential, which is credential probing from an unintended source and was not specifically authorized by the user.

That is the right refusal. It also means the agent cannot self-recover, which raises the value of naming one exact path rather than leaving it to improvise.

Both docs now name that single path and say explicitly **not** to glob for credential files. Reading one path the user told you about is following instructions; hunting for credentials is not, and sandboxes are right to block the second.

**The part that actually matters** is the instruction to source it in the *same command* as the request:

```
. ~/.codex/placecall.env && curl ...
```

Each command runs in its own shell, so an `export` in one does not carry to the next. "Export it in your shell" is true for a human and quietly false inside an agent, and that distinction is why the first attempt failed.

Verified by the same run: with this pattern, the **AGENTS.md-only path placed a real call**, `b7c69b09-03a9-40da-a107-8f3480bf5f75`, reaching a live person. The skill was parked at `/tmp` for that test so AGENTS.md alone was driving.

## 2. The documented event poll times out every time

Raised `--max-time` from 5s to 20s in both docs.

The 5s recipe produced a run of `curl: (28) Operation timed out after 5000 milliseconds` on **every one of three consecutive live runs**, two on Codex and one on Claude Code. The loop is correct and recovers, but a first-time user watches a wall of timeout errors during a call that is working perfectly. Cosmetic, and badly timed: it reads as a broken integration at the exact moment we are asking for confidence.

## Verified

`claude plugin validate --strict` passes. No em dashes in the added lines (the pre-existing 117 in `SKILL.md` and `AGENTS.md` are untouched, as agreed).

## Two things NOT fixed here, both worth their own look

- **`credits_reserved: 0`** on both live calls today. The README claims every call takes "a refundable **30-credit hold** at dial time (3x the charge, settled down to 10 on success)" and that under 30 available `POST /calls` returns `402`. Prod returns a hold of zero. Either the mechanic changed or it does not apply on this path, but we are documenting billing behaviour the API contradicts. Overlaps #553's open item on confirming the credits claims.
- **Over-confirmation in the brief guidance.** Today's two calls to the same venue differed only in the brief: an unconditional "read the closing time back to confirm" produced three utterances about one fact and "I told you five times already", while a conditional "confirm only if the answer is ambiguous" produced a clean two-turn call. The brief guidance should distinguish bookings (read-back earns its keep) from single-fact inquiries (it costs patience for nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cm1gGa85tG6R5SBpwbGwe
