### PR TITLE
docs: key signup via the web form only (retire the curl line)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ Installing the skill does **not** need a key; **placing calls does.** Keys are
 **self-serve** - no need to contact anyone:
 
 1. Open <https://api.voygr.tech/checkout> and click **"Get free API key"**
-   (name + email), or `curl -s -X POST https://api.voygr.tech/signup -H
-   "Content-Type: application/json" -d '{"name":"<you>","email":"<you@example.com>"}'`.
+   (name + email).
 2. The key arrives **by email** (it is never shown in the browser or API
    response). Free tier: **2,500 credits** (250 successful calls) with a
    25-calls/day cap. **Any credit purchase lifts the cap to 5,000/day** -

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -40,10 +40,11 @@ for you. Do NOT web-search for businesses; suggest is the discovery step.
   credential files** (`.env` globs and similar). Reading one path the user
   told you about is fine, hunting for credentials is not, and agent sandboxes
   correctly refuse it.
-- **No key yet? Self-serve, no human in the loop:** open
-  <https://api.voygr.tech/checkout> and use **"Get free API key"** (name +
-  email), or `POST /signup` with `{"name":"...","email":"..."}` — the key is
-  **emailed** to you, never returned in the response. The free tier comes with
+- **No key yet? Self-serve:** send the user to
+  <https://api.voygr.tech/checkout> to click **"Get free API key"** (name +
+  email; the page carries the API Terms they agree to). The key is **emailed**
+  to them, never shown in the browser; ask them to paste it here once it
+  arrives. The free tier comes with
   2,500 credits (enough for 250 successful calls) and a 25-calls/day cap;
   any credit purchase lifts the cap to 5,000/day (credits become the only
   practical limit). Lost your key? <https://api.voygr.tech/recover> emails


### PR DESCRIPTION
Removes the `POST /signup` curl advertisement from README + SKILL.md per today's decision: the endpoint was never designed as an agent-facing path — no disclosure/assent moment — and agents didn't use it anyway. The route stays live (it backs the checkout form and the signup canary); it just stops being advertised. SKILL.md now tells the agent: send the user to checkout, then ask them to paste the emailed key.

Agent-native signup done properly (device-code exchange + assent) is filed separately as a Later feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bab3xfR2DAwXZzykJcSRdU
