### PR TITLE
docs: Cowork needs the API domain allowed and the key in settings.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,5 +109,11 @@ whenever available < 30, even with a non-zero balance. Top-ups are self-serve at
 tier/entitlement · `409` concurrency cap (cancel an `active_call_id` or wait;
 raise via `PUT /users/me/limits`) · `429` rate limit (10 r/s, 100 r/min) or
 daily call ceiling (calls created per UTC day) · `503` maintenance/transient.
+**Blocked before it reaches us is not an API error.** A sandbox refusal,
+connection error or approval denial (no JSON body, no HTTP status) means the
+request never left the machine: don't retry, don't say the API is down. Tell the
+user to allow `api.voygr.tech` in their agent's network settings, and if the key
+is unset with no shell to export it in, to set `PLACECALL_API_KEY` in their
+agent's config. Never scan for `.env` files; read only a path the user names.
 Only dial numbers you're authorized to call. US destinations only; every call
 discloses it's a recorded AI call.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,32 @@ Same package as the Claude Code plugin, no terminal at all:
 2. Paste `voygr-tech/placecall`
 3. Click **Install** on the PlaceCall card
 
-Auto-updates from this repo, like the Code plugin. Add your key the same way as
-everywhere else (next section).
+Auto-updates from this repo, like the Code plugin.
+
+**Then do both of these, in `~/.claude/settings.json`.** Cowork has no terminal,
+so the `export` in the next section has nothing to run in, and the Bash sandbox
+blocks our API until you allow it:
+
+```json
+{
+  "env": { "PLACECALL_API_KEY": "<your key>" },
+  "sandbox": { "network": { "allowedDomains": ["api.voygr.tech"] } }
+}
+```
+
+Restart Cowork afterwards. Why each half matters:
+
+- **`env`** puts the key somewhere that survives a reboot. Setting it in a shell
+  does not reach a desktop app, which never sees that shell.
+- **`allowedDomains`** pre-allows `api.voygr.tech`. Claude Code pre-allows no
+  domains, so without this you get a permission prompt on the first call, and if
+  your organisation sets `strictAllowlist` or `allowManagedDomainsOnly` the call
+  is **blocked outright with no prompt**. That is the "deep admin setting" people
+  hit.
+
+Your key sits in plaintext in that file, same trust level as the `600` env file
+in the next section. `chmod 600 ~/.claude/settings.json` if you want the file
+permissions to match.
 
 > **Not claude.ai Chat.** Plugins reach Claude Code and Cowork. They do not add
 > anything to Claude chat conversations. The API is still just HTTP, so any agent
@@ -120,6 +144,12 @@ unset KEY
 # then, in any new shell where you want to place calls:
 source ~/.codex/placecall.env
 ```
+
+**No shell at all?** A desktop app never sees your shell environment, so neither
+of the above reaches it. Put the key in the `env` block of
+`~/.claude/settings.json` instead, which survives restarts. See the
+[Cowork](#cowork) section, which also covers the sandbox domain allowlist you
+need there.
 
 **Verify** (prints your quota, never the key):
 ```sh

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -394,6 +394,23 @@ free tier, 5,000/day once you've purchased credits — and resets at UTC
 midnight, see `resets_at`) · `503` maintenance
 window or transient refusal — retry later.
 
+**Blocked before it reaches the API is NOT an API error.** If the request fails
+with a sandbox/permission refusal, a connection error, or an approval denial
+rather than a JSON body and an HTTP status, the call never left the machine.
+**Do not retry, and do not tell the user the API is down.** Say which of these
+it was and give the fix:
+
+- **Network refused / domain not allowed.** Agent sandboxes allow no outbound
+  hosts by default. On Claude Code the user adds `api.voygr.tech` to
+  `sandbox.network.allowedDomains` in `~/.claude/settings.json`; on a managed
+  machine an admin may have to, because `strictAllowlist` and
+  `allowManagedDomainsOnly` block instead of prompting.
+- **Key missing and no shell to set it in** (desktop apps never see your shell).
+  The user puts `PLACECALL_API_KEY` in the `env` block of the same settings file.
+- **Refused for reading a credential file.** Expected: never scan for `.env`
+  files. Read only the one path the user names, or send them to
+  <https://api.voygr.tech/checkout>.
+
 ## Gotchas (learned the hard way)
 1. **Put ALL details in the `brief`.** The bot can only say what it was given.
 2. **The freeform `call_id` is nested** — `201` returns `{"call": {"call_id":


### PR DESCRIPTION
Two things block a Cowork install, and neither was documented. Both are fixed by one `~/.claude/settings.json`:

```json
{
  "env": { "PLACECALL_API_KEY": "<your key>" },
  "sandbox": { "network": { "allowedDomains": ["api.voygr.tech"] } }
}
```

## Why each half is needed

**The sandbox blocks the API.** Claude Code's sandboxed Bash tool does network isolation and pre-allows no domains, so the first call to `api.voygr.tech` is refused. On an unmanaged machine you get a permission prompt. On a managed one, where `strictAllowlist` or `allowManagedDomainsOnly` is set, it is **blocked outright with no prompt**, so there is nothing to approve and no visible cause. That is the failure most likely to be misread as "the API is broken".

**The key cannot live in a shell.** Both key paths documented until now assume one: `export` for the session, or sourcing a `600`-perm env file. A desktop app never sees a shell, so neither reaches it. The `env` block of the same settings file does, and it survives a restart.

## The part that matters more than the README

The same guidance goes into `SKILL.md` and `AGENTS.md`, because **the party that hits this is the agent, not the person doing setup.**

A sandbox refusal arrives with no JSON body and no HTTP status, so it is not an API error. Without guidance an agent either retries a request that can never succeed, or reports the API as down, which blames the wrong thing. Both docs now tell it to distinguish the three cases and hand back the exact remedy:

- network refused, so allow the domain
- key unset with no shell to export it in, so use the config `env` block
- refused for reading a credential file, which is expected, so read only a path the user names and never scan for `.env` files

That last one is not hypothetical: an agent hitting a missing key tried a filesystem sweep for `.env` files, and its sandbox correctly refused it as credential probing.

## Tradeoff stated rather than hidden

A key in `settings.json` sits in plaintext, the same trust level as the `600` env file already recommended, with a `chmod 600` suggestion so the permissions match.

## Not addressed

Putting a key into a config file is poor UX on a GUI surface, and no amount of documentation fixes that. A proper auth flow for this rail is separate work.
