### PR TITLE
Surface attribution: X-Client-Surface on every call, ?src on signup links (callwright#574)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,18 @@ No phone number at hand ("find me a florist and call them")? Use
   `. ~/.codex/placecall.env && curl ...` (an `export` does not carry between
   commands). No such file: send the user to /checkout. Never glob for `.env`
   files, which is credential hunting and sandboxes refuse it.
-- No key? Self-serve at <https://api.voygr.tech/checkout> ("Get free API key" —
-  emailed, free tier: 2,500 credits, 25 calls/day). Recovery: `/recover`.
+- No key? Self-serve at <https://api.voygr.tech/checkout?src=gh-repo> ("Get free
+  API key" — emailed, free tier: 2,500 credits, 25 calls/day). Recovery: `/recover`.
 - Check: `curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/users/me`
+- Surface marker: every `POST /calls` below carries `-H "X-Client-Surface: gh-repo"`.
+  Keep it as written — it tells PlaceCall which listing these instructions came
+  from (telemetry only; never affects auth, billing or the call).
 
 ## Place a call — one endpoint, everything in the brief
 ```sh
 curl -s -X POST https://api.voygr.tech/calls \
   -H "X-API-Key: $PLACECALL_API_KEY" -H "Content-Type: application/json" \
+  -H "X-Client-Surface: gh-repo" \
   -d '{"target_phone":"+1XXXXXXXXXX","brief":"<the full task in plain English>","language":"en","ask_user_mode":"stream"}'
 # -> 201 {"call":{"call_id":"...","status":"dialing",...},"credits_reserved":30,...}
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ lead-gen, appointment-setting.
 ```sh
 curl -s -X POST https://api.voygr.tech/calls \
   -H "X-API-Key: $PLACECALL_API_KEY" -H "Content-Type: application/json" \
+  -H "X-Client-Surface: gh-repo" \
   -d '{"target_phone":"+1XXXXXXXXXX","brief":"Call this restaurant and ask what time the kitchen closes tonight.","language":"en"}'
 ```
 
@@ -117,14 +118,14 @@ reference; a model with a shell tool can place calls straight from it.
 Installing the skill does **not** need a key; **placing calls does.** Keys are
 **self-serve** - no need to contact anyone:
 
-1. Open <https://api.voygr.tech/checkout> and click **"Get free API key"**
+1. Open <https://api.voygr.tech/checkout?src=gh-repo> and click **"Get free API key"**
    (name + email).
 2. The key arrives **by email** (it is never shown in the browser or API
    response). Free tier: **2,500 credits** (250 successful calls) with a
    25-calls/day cap. **Any credit purchase lifts the cap to 5,000/day** -
    once you've paid, credits are your only practical limit.
 3. Lost the key? <https://api.voygr.tech/recover> emails you a new one.
-4. Need more credits? Top up on the same <https://api.voygr.tech/checkout>
+4. Need more credits? Top up on the same <https://api.voygr.tech/checkout?src=gh-repo>
    page (Stripe-hosted payment).
 
 Then set the key in your shell:
@@ -190,7 +191,7 @@ how to wrap up). One endpoint, describe the task, done.
   **30-credit hold** at dial time (3× the charge, settled down to 10 on
   success) - under 30 available and `POST /calls` returns `402` even with a
   non-zero balance (`GET /users/me` for your balance; top-ups are self-serve
-  at <https://api.voygr.tech/checkout>).
+  at <https://api.voygr.tech/checkout?src=gh-repo>).
 - After a call `completed`, the outcome/transcript can populate a moment
   *after* the status flips - poll `GET /calls/{id}` until `outcome_type` is
   non-null.

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -36,12 +36,12 @@ for you. Do NOT web-search for businesses; suggest is the discovery step.
   SAME shell command as the request: `. ~/.codex/placecall.env && curl ...`.
   An `export` in one command does NOT carry to the next, because each command
   runs in its own shell. If that file does not exist, tell the user to get a
-  key at <https://api.voygr.tech/checkout>. **Do NOT search the filesystem for
+  key at <https://api.voygr.tech/checkout?src=claude-plugin>. **Do NOT search the filesystem for
   credential files** (`.env` globs and similar). Reading one path the user
   told you about is fine, hunting for credentials is not, and agent sandboxes
   correctly refuse it.
 - **No key yet? Self-serve:** send the user to
-  <https://api.voygr.tech/checkout> to click **"Get free API key"** (name +
+  <https://api.voygr.tech/checkout?src=claude-plugin> to click **"Get free API key"** (name +
   email; the page carries the API Terms they agree to). The key is **emailed**
   to them, never shown in the browser; ask them to paste it here once it
   arrives. The free tier comes with
@@ -49,6 +49,11 @@ for you. Do NOT web-search for businesses; suggest is the discovery step.
   any credit purchase lifts the cap to 5,000/day (credits become the only
   practical limit). Lost your key? <https://api.voygr.tech/recover> emails
   you a fresh one.
+- **Surface marker:** every `POST /calls` in this skill carries
+  `-H "X-Client-Surface: claude-plugin"`. Keep it exactly as written — it
+  tells PlaceCall which listing this skill came from (telemetry only; it
+  never affects auth, billing or the call). Same for the `?src=claude-plugin`
+  on the checkout links.
 - **Rules:** only dial numbers you're authorized to call — a real call costs
   credits and rings a real phone. US destinations only. Every call announces
   it's an AI assistant and that it's recorded (non-configurable).
@@ -69,6 +74,7 @@ it in the brief. The bot reads **only** the `brief`, so put every detail in it.
 ```sh
 curl -s -X POST https://api.voygr.tech/calls \
   -H "X-API-Key: $PLACECALL_API_KEY" -H "Content-Type: application/json" \
+  -H "X-Client-Surface: claude-plugin" \
   -d '{
         "target_phone": "+15551234567",
         "brief": "Call this sports bar and find out (1) whether they are showing the USA vs Netherlands match today and (2) whether a reservation is needed. Read the answers back to confirm, thank them, and end.",
@@ -129,6 +135,7 @@ brief deterministically. Five intents:
 ```sh
 curl -s -X POST https://api.voygr.tech/calls \
   -H "X-API-Key: $PLACECALL_API_KEY" -H "Content-Type: application/json" \
+  -H "X-Client-Surface: claude-plugin" \
   -d '{"target_phone": "+15551234567", "intent": "info_gathering",
        "language": "en", "ask_user_mode": "stream",
        "slots": {"target_phone": "+15551234567",
@@ -240,6 +247,7 @@ asked).
 # phone and brief come straight off the card you picked
 curl -s -X POST https://api.voygr.tech/calls \
   -H "X-API-Key: $PLACECALL_API_KEY" -H "Content-Type: application/json" \
+  -H "X-Client-Surface: claude-plugin" \
   -d '{
         "target_phone": "<card phone_e164>",
         "brief": "<card call_brief — as-is, or edited>",
@@ -379,7 +387,7 @@ charge (success) or is fully refunded (failure). So `POST /calls` returns
 `402 insufficient credits` whenever your available balance is under **30** —
 even though a call only *costs* 10. Keep ≥30 headroom per concurrent call.
 
-**Top-ups are self-serve:** <https://api.voygr.tech/checkout> (Stripe-hosted
+**Top-ups are self-serve:** <https://api.voygr.tech/checkout?src=claude-plugin> (Stripe-hosted
 payment; credit packs listed at `GET /checkout/packs`). The 402 body also
 carries a `checkout_url`.
 


### PR DESCRIPTION
Artifact half of voygr-tech/callwright#574 (per-surface attribution): PlaceCall is listed on a dozen surfaces and until now no call could say which listing produced it.

## What changes

Two markers per artifact, both telemetry — they never affect auth, billing or the call:

1. **Signup links carry `?src=<surface>`** (`/checkout?src=…`), and the signup curl carries `"src"`. poi-billing stamps it onto the key at issuance (poi_enrichment #457), so every call the key ever places inherits it.
2. **Every `POST /calls` carries `X-Client-Surface: <surface>`.** callwright records it beside the key's origin, which lets a listing that lost its `?src` show up as a mismatch instead of vanishing into `direct`.

## Which constant goes where

| file | constant | why |
|---|---|---|
| `skills/call/SKILL.md` | `claude-plugin` | Claude Code plugin, Cowork, the community catalog and Codex's `$skill-installer` all install this ONE file. One artifact → one bucket, by design (the "known blur" in #574). |
| `README.md`, `AGENTS.md` | `gh-repo` | both are what someone reads after finding the repository on GitHub |

The marker names the **surface**, never the build or version, so it survives the plugin auto-updating and the skill being copied into a cache. A malformed or missing value is recorded as `unattributed` on our side — it can never cost a call.

## Sequencing

Both server halves are already merged and live in production: callwright voygr-tech/callwright#848 records `origin` / `reported_surface` on every call, and the gateway (voygr-tech/poi_enrichment#466) forwards `X-Client-Surface` on the call-placing routes. `?src=` has worked since #457. So this PR is the last missing piece — the transmitter for a receiver that is already listening. Verified end to end on the test environment: a `POST /calls` carrying `X-Client-Surface: test-plugin` landed as `reported_surface='test-plugin'` in the calls table.

## What this does NOT change

- Nothing about auth, billing or the call itself: the header is optional telemetry; an unreadable value is recorded as `unattributed`, never rejected.
- No behaviour change for people who already have a key — only what a *new* signup link carries and what each call declares about its origin.

Refs voygr-tech/callwright#574

🤖 Generated with [Claude Code](https://claude.com/claude-code)
