### PR TITLE
fix: remove an endpoint that does not exist, state the real concurrency limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,8 +110,8 @@ Each call takes a refundable **30-credit hold** (3× the charge) at dial time �
 settled down to 10 on success, fully refunded on failure — so `402` fires
 whenever available < 30, even with a non-zero balance. Top-ups are self-serve at
 <https://api.voygr.tech/checkout> (Stripe). Other errors: `403`
-tier/entitlement · `409` concurrency cap (cancel an `active_call_id` or wait;
-raise via `PUT /users/me/limits`) · `429` rate limit (10 r/s, 100 r/min) or
+tier/entitlement · `409` concurrency cap (cancel an `active_call_id` or wait; the
+free tier allows 1 concurrent call and there is NO endpoint to raise it) · `429` rate limit (10 r/s, 100 r/min) or
 daily call ceiling (calls created per UTC day) · `503` maintenance/transient.
 **Blocked before it reaches us is not an API error.** A sandbox refusal,
 connection error or approval denial (no JSON body, no HTTP status) means the

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -370,8 +370,12 @@ curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/calls/$ID
 - `GET /calls?limit=20` — list your calls, most recent first (no transcripts).
 - `POST /calls/{id}/cancel` — cancel a not-yet-terminal call, releases the
   hold. Idempotent: `{"cancelled": false}` for unknown/terminal calls, never 404.
-- `PUT /users/me/limits` — raise your own `max_concurrent_calls` up to the
-  key's admin ceiling (`max_concurrent_calls_ceiling` on `GET /users/me`).
+
+**Concurrency is 1 on the free tier, and you cannot raise it.** `GET
+/users/me` reports `max_concurrent_calls` (1) and
+`max_concurrent_calls_ceiling` (higher), but there is **no endpoint to change
+it**: `/users/me` is GET-only. So a second call started while one is live
+returns `409`, and the fix is to wait or cancel, never to raise a limit.
 
 ## Credits & top-ups
 


### PR DESCRIPTION
Both `SKILL.md` and `AGENTS.md` advertised **`PUT /users/me/limits`** as the way to raise your own concurrency. **That route returns 404.** The live OpenAPI spec has exactly one `/users` path, `GET /users/me`, and no limits endpoint anywhere:

```
PUT /users/me/limits  ->  404 {"detail":"Not Found"}
```

So an agent that hit a `409` concurrency cap was being told to call a route that does not exist. That turns a recoverable wait-or-cancel into a dead end, and it is the agent, not a human, that reads this and acts on it.

## What is actually true

Measured against a live free-tier key:

| Field | Value |
|---|---|
| `max_concurrent_calls` | **1** |
| `max_concurrent_calls_ceiling` | higher, but **unreachable** |

The ceiling is reported and cannot be acted on. So the only correct response to a `409` is to wait or cancel an active call, which is what both docs now say.

## Also newly stated: the free tier allows one concurrent call

Neither doc mentioned this. `SKILL.md` documented `409 concurrent-call limit` as an error without ever saying the free-tier limit **is** one. A developer evaluating the API will naturally fire two calls to see what happens, get an immediate `409`, and have no way to distinguish a tier limit from a bug.

## Verified

`claude plugin validate --strict` passes. No em dashes in the added lines.

## Related, not fixed here

The `credits_hold_per_call: 30` field is configured, but `credits_held` is 0 and two real calls both returned `"credits_reserved": 0`. So the documented claim that a `402` fires below 30 credits describes behaviour prod may not have. Left alone deliberately: that one needs a decision about which side is wrong, the docs or the billing path.