### PR TITLE
Correct the ClawHub metadata key, and lead SKILL.md with the human sections

### DIFF
--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -4,26 +4,102 @@ description: Use WHENEVER the user wants to make a phone call, call a number, as
 version: 6.0.0
 author: voygr-tech
 license: MIT
-platforms: [linux, macos, windows]
 metadata:
+  openclaw:
+    primaryEnv: PLACECALL_API_KEY
+    requires:
+      env:
+        - PLACECALL_API_KEY
+    emoji: "☎️"
+    homepage: https://github.com/voygr-tech/placecall
+    os: [linux, macos, windows]
+    tags: [phone, calls, voice, telephony, api, sse, events, booking, places, search, discovery]
   hermes:
     tags: [phone, calls, voice, telephony, api, sse, events, booking, places, search, discovery]
     related_skills: []
 ---
 
-# PlaceCall — place real phone calls via one REST API
+# PlaceCall ☎️
 
-You CAN place real phone calls. You do NOT need a native voice/telephony tool —
+PlaceCall gives your agent a phone: it calls US businesses, asks the question,
+books or cancels the table, chases the order, then reports back with the
+outcome and a full transcript.
+
+## What Is This
+
+Most businesses still answer a phone and have no API. PlaceCall is the phone.
+Hand it a US number and the task in plain English; it dials, speaks with
+whoever answers, works through phone menus and hold music, and hands back a
+structured outcome plus a transcript of what was actually said.
+
+No number to hand? Describe the place instead ("a romantic restaurant in
+Chicago, Saturday 8pm") and PlaceCall finds the candidates, says why it picked
+them, and writes the call brief for you. That step is free.
+
+**Everything goes in the brief.** The agent on the call reads only that, so put
+the whole task in it: what to ask, who you are calling for, names, dates, party
+size, a callback number, how to wrap up.
+
+## When to Use
+
+Use PlaceCall when the human wants to:
+
+- call a number, or call a business and ask it something
+- book or cancel a restaurant table or an appointment
+- chase an order, a delivery, or a problem with a service
+- settle a fact only a phone call will settle: opening hours, availability,
+  whether they have it in stock
+- find a business to call when no number is at hand
+- check how a call went, or answer a question the agent raised mid-call
+
+## What You Get Back
+
+Every call ends with one of fourteen outcomes and a full transcript. Three are
+success: booked, refused, or answered without a booking. The other eleven say
+plainly what went wrong: nobody answered, line busy, voicemail, hung up on,
+dropped mid-call, wrong number, hold queue never produced a person.
+
+**You are billed only when a real conversation happened.** No answer, voicemail
+and hang-ups cost nothing.
+
+## Setup
+
+Installing the skill needs no key. Placing calls does, and keys are self-serve.
+
+1. Get a free key at https://api.voygr.tech/checkout?src=clawhub with your name
+   and email. The key arrives by email.
+2. Put it in this skill's `apiKey` slot in `~/.openclaw/openclaw.json`, or set
+   `PLACECALL_API_KEY`. Never paste a key into a prompt.
+3. **Restart OpenClaw.** Skills are snapshotted at session start, so a fresh
+   install does nothing until you do.
+
+Free tier: 2,500 credits, about 250 successful calls, capped at 25 calls a day.
+
+## Limits
+
+- **US destination numbers only.**
+- English is the most reliable language; twelve others are accepted and are
+  best-effort.
+- **Every call opens by disclosing that it is a recorded AI call.** A call that
+  cannot deliver that disclosure is ended before anyone speaks, and is not
+  billed.
+- Calls are recorded. Recordings and transcripts are kept for 90 days.
+- Only call numbers you are authorised to call. Real calls ring real phones.
+- Not for SMS, email, or calls outside the US.
+
+## For the agent
+
+You CAN place real phone calls. You do NOT need a native voice/telephony tool:
 you make calls by sending HTTP requests to the PlaceCall API with your
 shell/terminal tool (`curl`). NEVER tell the user you cannot make calls or that
 you lack a voice function. When the user asks to call, ask, book, or cancel by
-phone — DO IT via this API.
+phone, DO IT via this API.
 
 The backend dials the number, talks to whoever answers (in the chosen language),
 performs the task described in your `brief`, and reports an outcome + transcript.
-**Two endpoints cover everything.** Know the number? `POST /calls` — everything
+**Two endpoints cover everything.** Know the number? `POST /calls`, everything
 goes in the `brief`. No number ("find me a florist and call them")?
-`POST /v1/places/suggest` first — it finds the places AND writes the `brief`
+`POST /v1/places/suggest` first: it finds the places AND writes the `brief`
 for you. Do NOT web-search for businesses; suggest is the discovery step.
 
 ## Connection


### PR DESCRIPTION
Two changes to `skills/call/SKILL.md`. No operational content is touched: everything from `## Connection` down is unchanged.

## 1. The metadata was under a key ClawHub does not read

The frontmatter declared `metadata.hermes` only, so none of it reached the registry.

- adds `metadata.openclaw` with `primaryEnv` and `requires.env` for `PLACECALL_API_KEY`. The per-skill `apiKey` config slot is documented as a convenience for skills that declare `primaryEnv`, so without this there is no clean way for a user to supply a key. They end up putting it somewhere worse.
- moves `platforms:` to `metadata.openclaw.os`, which is the field the schema defines. Nothing else read `platforms`.
- adds `emoji` and `homepage`.
- carries the tag list over. `tags` is not in the documented schema, but published skills use undocumented keys under the same parent, so it is free if ignored.
- leaves `metadata.hermes` alone, since nothing has confirmed whether that registry reads it.

## 2. The body is the listing page, and it opened badly

Registries that render `SKILL.md` show the body as the page a stranger reads. Ours opened with `You CAN place real phone calls. You do NOT need... NEVER... DO IT via this API`, then went straight into base URLs and curl.

Now it opens with **What Is This**, **When to Use**, **What You Get Back**, **Setup**, **Limits**, and only then the mechanics.

The agent-facing imperatives are **not removed**, just moved under `## For the agent`. A model reads the whole file, so ordering costs it nothing in tool selection.

Two sections earn their place:

- **Setup** names the three things a first-time user gets wrong: where the key goes, that it must never be pasted into a prompt, and that the client has to be restarted because skills are snapshotted at session start.
- **Limits** states US-only destinations, best-effort non-English, the recorded-call disclosure, and the 90-day retention.

## Not in this PR

- The frontmatter `description` is unchanged. It is still written as an agent trigger, which is defensible since it doubles as the runtime match target, but it is also the public listing summary and reads as machine instructions. Worth a separate decision.
- The pre-existing body still contains em dashes; only the new text avoids them.
- The free-tier figures quoted in Setup have not been re-verified against a fresh key.