### PR TITLE
Make the skill description a description, not an agent trigger

### DIFF
--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: placecall
-description: Use WHENEVER the user wants to make a phone call, call a number, ask a business something by phone, book or cancel a reservation, find a place or business to call when no phone number is at hand ("find me a florist and call them"), check a call's status/outcome, or answer a question the call bot asked mid-call. Places REAL outbound voice calls via the PlaceCall REST API and follows the call. Always consult this skill before saying you cannot make calls or find businesses to call.
+description: PlaceCall gives your agent a phone. It calls US businesses, asks the question, books or cancels the table, chases the order, then reports back with the outcome and a full transcript.
 version: 6.0.0
 author: voygr-tech
 license: MIT
@@ -21,7 +21,7 @@ metadata:
 
 # PlaceCall ☎️
 
-PlaceCall gives your agent a phone: it calls US businesses, asks the question,
+PlaceCall gives your agent a phone. It calls US businesses, asks the question,
 books or cancels the table, chases the order, then reports back with the
 outcome and a full transcript.
 


### PR DESCRIPTION
One line in `skills/call/SKILL.md`, plus the body lead punctuated to match.

The frontmatter `description` does four jobs at once: it is the listing summary a person reads on a registry, the Overview on the generated skill card, the registry's search text, and the string a model matches on at runtime. It was 484 characters opening with `Use WHENEVER the user wants to...`, which reads as instructions to a machine and is long enough to be truncated behind a Show more fold, so the part that sells never appears.

Now 182 characters:

> PlaceCall gives your agent a phone. It calls US businesses, asks the question, books or cancels the table, chases the order, then reports back with the outcome and a full transcript.

Why this length and this voice:

- Every comparable listing in the category sits between 166 and 193 characters. The one that runs to 420 is also the one with the fewest recent installs.
- At 182 it fits without the fold, so the whole thing is visible on the listing card.
- It repeats the promise the README's own heading already makes, so the repo and the registry say the same thing rather than diverging.

**The trigger vocabulary is not lost.** The six intents moved into the `## When to Use` section of the body in the previous change, and registries that render the body also index it.

## One parser detail worth keeping

There is no colon in the value. An unquoted YAML scalar containing `": "` parses as a nested mapping and the frontmatter fails to load, which is exactly what happened on the first attempt here. Quoting would also work, but a full stop is one less thing for a naive parser to get wrong. The body lead is punctuated the same way so the two match.

## Not in this PR

The generated skill card's Review Before Use section is derived from the body, and the body still describes the recording disclosure and the retention window as features rather than as risk and mitigation. It also does not mention the pre-call guard that refuses briefs asking a callee for government identification or medical data, nor the refusal to answer with payment credentials, so a generated card cannot credit either. Separate change.