### PR TITLE
No pricing figures in the agent-facing files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ No phone number at hand ("find me a florist and call them")? Use
   commands). No such file: send the user to /checkout. Never glob for `.env`
   files, which is credential hunting and sandboxes refuse it.
 - No key? Self-serve at <https://api.voygr.tech/checkout?src=gh-repo> ("Get free
-  API key" — emailed, free tier: 2,500 credits, 25 calls/day). Recovery: `/recover`.
+  API key", emailed; that page also shows what a new key includes and the
+  current rates). Recovery: `/recover`.
 - Check: `curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/users/me`
 - Surface marker: every `POST /calls` below carries `-H "X-Client-Surface: gh-repo"`.
   Keep it as written — it tells PlaceCall which listing these instructions came
@@ -49,8 +50,8 @@ curl -s -X POST https://api.voygr.tech/calls \
   bot a callback number to read back (staff ask for one more often than not).
 
 ## No number? Find the place first — `POST /v1/places/suggest`
-Free-text need → up to 4-6 ranked place cards, each ready to dial. **Free**
-(never billed; own limits: 10/min, 1000/UTC-day, separate from call limits).
+Free-text need → up to 4-6 ranked place cards, each ready to dial. Own
+limits: 10/min, 1000/UTC-day, separate from call limits.
 US only, English in/out.
 ```sh
 curl -s -X POST https://api.voygr.tech/v1/places/suggest \
@@ -96,7 +97,7 @@ Returns `status`, `outcome_type`, `outcome_summary`, `transcript_full`.
 keep polling every few seconds until `outcome_type` is non-null — the result
 persists just after the status flips.** Always report from `transcript_full`
 (`success_no_booking` = billable success: info obtained, no booking). Outcomes:
-`success_booked|success_refused|success_no_booking` (billed, 10 credits) ·
+`success_booked|success_refused|success_no_booking` (billed) ·
 `failed_short_hangup` (most common failure — picked up, hung up early) ·
 `failed_voicemail|failed_no_answer|failed_busy|failed_no_agent_available|failed_no_disclosure|failed_technical` (all free).
 Recording: when `has_recording` is true, GET `recording_url` (relative path)
@@ -105,11 +106,11 @@ with your API key to download the audio. Merged post-call transcript:
 
 ## Credits & errors
 `GET /v1/usage` → remaining (or `GET /users/me` → `credits_available`).
-**Only `success_*` outcomes are billed (10 credits); every `failed_*` is 0.**
-Each call takes a refundable **30-credit hold** (3× the charge) at dial time —
-settled down to 10 on success, fully refunded on failure — so `402` fires
-whenever available < 30, even with a non-zero balance. Top-ups are self-serve at
-<https://api.voygr.tech/checkout> (Stripe). Other errors: `403`
+**Only `success_*` outcomes are billed; every `failed_*` costs nothing.**
+Each call takes a refundable hold at dial time that is larger than the charge,
+settled to the charge on success and refunded in full on failure, so `402` can
+fire while the balance still looks sufficient for the charge alone. Rates and
+top-ups are self-serve at <https://api.voygr.tech/checkout> (Stripe). Other errors: `403`
 tier/entitlement · `409` concurrency cap (cancel an `active_call_id` or wait;
 raise via `PUT /users/me/limits`) · `429` rate limit (10 r/s, 100 r/min) or
 daily call ceiling (calls created per UTC day) · `503` maintenance/transient.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 whoever answers, works through menus/hold, and returns a structured result + full
 transcript. No number yet? `POST /v1/places/suggest` turns "book a romantic
 restaurant in Chicago Saturday 8pm" into ready-to-dial place cards - phone,
-reasoning, and a ready-made call brief - free of charge. It's how your agent
+reasoning, and a ready-made call brief. It's how your agent
 reaches the ~80% of businesses that have a phone, not an API - inquiries, booking,
 lead-gen, appointment-setting.
 
@@ -121,9 +121,8 @@ Installing the skill does **not** need a key; **placing calls does.** Keys are
 1. Open <https://api.voygr.tech/checkout?src=gh-repo> and click **"Get free API key"**
    (name + email).
 2. The key arrives **by email** (it is never shown in the browser or API
-   response). Free tier: **2,500 credits** (250 successful calls) with a
-   25-calls/day cap. **Any credit purchase lifts the cap to 5,000/day** -
-   once you've paid, credits are your only practical limit.
+   response). What a new key includes, and the current credit rates, are
+   shown on the checkout page.
 3. Lost the key? <https://api.voygr.tech/recover> emails you a new one.
 4. Need more credits? Top up on the same <https://api.voygr.tech/checkout?src=gh-repo>
    page (Stripe-hosted payment).
@@ -186,12 +185,12 @@ in it (what to ask, who you're calling for, names/dates/party size/callback numb
 how to wrap up). One endpoint, describe the task, done.
 
 ## Good to know
-- **Only successful calls are billed** (10 credits per `success_*` outcome;
-  voicemails/hangups/no-answers are free). Each call takes a refundable
-  **30-credit hold** at dial time (3× the charge, settled down to 10 on
-  success) - under 30 available and `POST /calls` returns `402` even with a
-  non-zero balance (`GET /users/me` for your balance; top-ups are self-serve
-  at <https://api.voygr.tech/checkout?src=gh-repo>).
+- **Only successful calls are billed**; voicemails, hangups and no-answers
+  cost nothing. Each call takes a refundable hold at dial time that is larger
+  than the charge, so `POST /calls` can return `402` while your balance still
+  looks sufficient for the charge alone (`GET /users/me` for your balance;
+  rates and top-ups are self-serve at
+  <https://api.voygr.tech/checkout?src=gh-repo>).
 - After a call `completed`, the outcome/transcript can populate a moment
   *after* the status flips - poll `GET /calls/{id}` until `outcome_type` is
   non-null.

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -34,7 +34,7 @@ structured outcome plus a transcript of what was actually said.
 
 No number to hand? Describe the place instead ("a romantic restaurant in
 Chicago, Saturday 8pm") and PlaceCall finds the candidates, says why it picked
-them, and writes the call brief for you. That step is free.
+them, and writes the call brief for you.
 
 **Everything goes in the brief.** The agent on the call reads only that, so put
 the whole task in it: what to ask, who you are calling for, names, dates, party
@@ -59,8 +59,8 @@ success: booked, refused, or answered without a booking. The other eleven say
 plainly what went wrong: nobody answered, line busy, voicemail, hung up on,
 dropped mid-call, wrong number, hold queue never produced a person.
 
-**You are billed only when a real conversation happened.** No answer, voicemail
-and hang-ups cost nothing.
+**A call is billed only when a real conversation happened.** No answer,
+voicemail and hang-ups cost nothing.
 
 ## Setup
 
@@ -73,7 +73,8 @@ Installing the skill needs no key. Placing calls does, and keys are self-serve.
 3. **Restart OpenClaw.** Skills are snapshotted at session start, so a fresh
    install does nothing until you do.
 
-Free tier: 2,500 credits, about 250 successful calls, capped at 25 calls a day.
+What a new key includes, and the current credit rates, are shown at
+<https://api.voygr.tech/checkout>.
 
 ## Limits
 
@@ -158,10 +159,8 @@ for you. Do NOT web-search for businesses; suggest is the discovery step.
   <https://api.voygr.tech/checkout?src=claude-plugin> to click **"Get free API key"** (name +
   email; the page carries the API Terms they agree to). The key is **emailed**
   to them, never shown in the browser; ask them to paste it here once it
-  arrives. The free tier comes with
-  2,500 credits (enough for 250 successful calls) and a 25-calls/day cap;
-  any credit purchase lifts the cap to 5,000/day (credits become the only
-  practical limit). Lost your key? <https://api.voygr.tech/recover> emails
+  arrives. What a new key includes, and the current credit rates, are on that
+  page. Lost your key? <https://api.voygr.tech/recover> emails
   you a fresh one.
 - **Surface marker:** every `POST /calls` in this skill carries
   `-H "X-Client-Surface: claude-plugin"`. Keep it exactly as written — it
@@ -493,13 +492,14 @@ curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/calls/$ID
 curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/v1/usage
 # {"remaining":...,"quota_limit":...,"current_usage":...,"tier":...}
 ```
-**Only successful calls are billed** — a `success_*` outcome costs **10
-credits**; every `failed_*` outcome costs **0**. Voicemails, hangups, and busy
-lines don't burn your quota. Each call takes a refundable **30-credit hold**
-(3× the charge) at dial time; on settlement the hold becomes the 10-credit
-charge (success) or is fully refunded (failure). So `POST /calls` returns
-`402 insufficient credits` whenever your available balance is under **30** —
-even though a call only *costs* 10. Keep ≥30 headroom per concurrent call.
+**Only successful calls are billed**: a `success_*` outcome costs credits,
+every `failed_*` outcome costs nothing, so voicemails, hangups and busy lines
+do not burn quota. Each call takes a **refundable hold at dial time that is
+larger than the charge**; on settlement it becomes the charge (success) or is
+refunded in full (failure). So `POST /calls` can return
+`402 insufficient credits` while your balance still looks sufficient for the
+charge alone. Keep headroom per concurrent call. Current rates are at
+<https://api.voygr.tech/checkout>.
 
 **Top-ups are self-serve:** <https://api.voygr.tech/checkout?src=claude-plugin> (Stripe-hosted
 payment; credit packs listed at `GET /checkout/packs`). The 402 body also
@@ -511,9 +511,9 @@ insufficient credits · `403` tier/entitlement not permitted · `409`
 concurrent-call limit (body lists `active_call_ids` — cancel one or wait) ·
 `422` validation (see `error_code` inside `detail`) · `429` rate limit (10
 req/s, 100 req/min) **or** daily call ceiling reached (distinguish by
-`detail.error`; the ceiling counts calls *created* per UTC day — 25/day on the
-free tier, 5,000/day once you've purchased credits — and resets at UTC
-midnight, see `resets_at`) · `503` maintenance
+`detail.error`; the ceiling counts calls *created* per UTC day, the limit
+depends on your tier, and it resets at UTC midnight, see `resets_at`) · `503`
+maintenance
 window or transient refusal — retry later.
 
 **Blocked before it reaches the API is NOT an API error.** If the request fails


### PR DESCRIPTION
Removes every pricing figure from `skills/call/SKILL.md`, `README.md` and `AGENTS.md`, and points at the checkout page instead. 13 edits, no content added beyond the pointers.

## Why

Credit grants, daily caps, per-call cost and the hold size were stated in three public files. Three problems with that:

- **They go stale silently.** The figures were already unverified against a fresh key, and the checkout page a new user actually sees states only the credit grant, deferring rates to the docs.
- **Store listings index claims, not presence.** A figure published to a registry outlives the release that introduced it.
- **Two of the claims are about to become false.** Place suggestions were described as "free of charge" in the README and "never billed" in AGENTS.md. That changes, and these files are on the list of places to fix when it does. Removing the claim now means the billing change does not need to touch them at all.

Pricing belongs on the checkout page and the site, which can change it in one place.

## What went

The credit grant, the successful-call count, both daily caps, the per-call cost, the hold size and the 3x multiplier. Every occurrence, verified by grep afterwards across all three files.

## What stayed, and why

Mechanics an agent has to handle are not prices, so they are kept and simply stated without numbers:

- only `success_*` outcomes are billed, `failed_*` cost nothing
- the hold taken at dial time is **larger than the charge**, so a `402` can fire while the balance still looks sufficient for the charge alone. This one matters: an agent that assumes balance greater than cost will hit an unexpected 402
- the daily ceiling counts calls *created* per UTC day and resets at midnight, with `resets_at` in the body

## One wording change beyond removal

`You are billed only when a real conversation happened` is now scoped to **a call**. Once suggestions bill separately, a user can be charged without any conversation having taken place, and the unscoped sentence would be misleading rather than merely imprecise.