### PR TITLE
Description: Vlad's listing copy, marked SOT

### DIFF
--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: placecall
-description: PlaceCall gives your agent a phone. It calls US businesses, asks the question, books or cancels the table, chases the order, then reports back with the outcome and a full transcript.
+description: The phone is your last API. Give your agent a voice to call any US business and take action in the real world. PlaceCall handles reservations, inquiries, and quotes - navigating IVRs, holds, and transfers. You get a verified outcome + full transcript. First 250 calls free. Pay only for outcomes.
 version: 6.0.0
 author: voygr-tech
 license: MIT


### PR DESCRIPTION
One line in `skills/call/SKILL.md`: the frontmatter `description` becomes the version Vlad wrote and Ilya marked as source of truth in the working document (2026-08-29).

> The phone is your last API. Give your agent a voice to call any US business and take action in the real world. PlaceCall handles reservations, inquiries, and quotes - navigating IVRs, holds, and transfers. You get a verified outcome + full transcript. First 250 calls free. Pay only for outcomes.

296 characters. This field is the listing summary, the generated trust card's Overview, the registry's search text, and the runtime match target, so it is the single most visible string in the artifact and should carry the decided copy before first publish (1.0.0 is what gets indexed).

Two mechanical changes from the document version, nothing editorial:

- the en dash is the file's spaced-hyphen convention
- verified it parses as an unquoted YAML scalar (no `": "` in the text; that exact failure broke this field once before)

"First 250 calls free" is carried deliberately, per the 2026-08-29 decision to advertise the grant; it also appears in the body from #25.