### PR TITLE
feat(skill): send X-Client-Agent telemetry on POST /calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,19 @@ No phone number at hand ("find me a florist and call them")? Use
 - Surface marker: every `POST /calls` below carries `-H "X-Client-Surface: gh-repo"`.
   Keep it as written — it tells PlaceCall which listing these instructions came
   from (telemetry only; never affects auth, billing or the call).
+- Client-agent marker: every `POST /calls` below also carries
+  `-H "X-Client-Agent: ${CLAUDECODE:+claude-code}${CURSOR_AGENT:+cursor}${CODEX_SANDBOX:+codex}${GEMINI_CLI:+gemini-cli}"`.
+  Each tool exports a distinct env var, so this expands to which tool placed the
+  call (`claude-code`/`cursor`/`codex`/`gemini-cli`) — telemetry only, sibling to
+  `X-Client-Surface`. If none is set the header is empty and PlaceCall falls back
+  to the User-Agent.
 
 ## Place a call — one endpoint, everything in the brief
 ```sh
 curl -s -X POST https://api.voygr.tech/calls \
   -H "X-API-Key: $PLACECALL_API_KEY" -H "Content-Type: application/json" \
   -H "X-Client-Surface: gh-repo" \
+  -H "X-Client-Agent: ${CLAUDECODE:+claude-code}${CURSOR_AGENT:+cursor}${CODEX_SANDBOX:+codex}${GEMINI_CLI:+gemini-cli}" \
   -d '{"target_phone":"+1XXXXXXXXXX","brief":"<the full task in plain English>","language":"en","ask_user_mode":"stream"}'
 # -> 201 {"call":{"call_id":"...","status":"dialing",...},"credits_reserved":30,...}
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ lead-gen, appointment-setting.
 curl -s -X POST https://api.voygr.tech/calls \
   -H "X-API-Key: $PLACECALL_API_KEY" -H "Content-Type: application/json" \
   -H "X-Client-Surface: gh-repo" \
+  -H "X-Client-Agent: ${CLAUDECODE:+claude-code}${CURSOR_AGENT:+cursor}${CODEX_SANDBOX:+codex}${GEMINI_CLI:+gemini-cli}" \
   -d '{"target_phone":"+1XXXXXXXXXX","brief":"Call this restaurant and ask what time the kitchen closes tonight.","language":"en"}'
 ```
 

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -170,6 +170,13 @@ for you. Do NOT web-search for businesses; suggest is the discovery step.
   tells PlaceCall which listing this skill came from (telemetry only; it
   never affects auth, billing or the call). Same for the `?src=claude-plugin`
   on the checkout links.
+- **Client-agent marker:** every `POST /calls` also carries
+  `-H "X-Client-Agent: ${CLAUDECODE:+claude-code}${CURSOR_AGENT:+cursor}${CODEX_SANDBOX:+codex}${GEMINI_CLI:+gemini-cli}"`.
+  Each tool exports a distinct env var (`CLAUDECODE`, `CURSOR_AGENT`,
+  `CODEX_SANDBOX`, `GEMINI_CLI`), so this expands to which tool placed the call
+  — `claude-code`, `cursor`, `codex` or `gemini-cli`. Telemetry only, sibling to
+  `X-Client-Surface`; never affects auth, billing or the call. If none of the
+  vars is set the header is empty and PlaceCall falls back to the User-Agent.
 - **Rules:** only dial numbers you're authorized to call — a real call costs
   credits and rings a real phone. US destinations only. Every call announces
   it's an AI assistant and that it's recorded (non-configurable).
@@ -191,6 +198,7 @@ it in the brief. The bot reads **only** the `brief`, so put every detail in it.
 curl -s -X POST https://api.voygr.tech/calls \
   -H "X-API-Key: $PLACECALL_API_KEY" -H "Content-Type: application/json" \
   -H "X-Client-Surface: claude-plugin" \
+  -H "X-Client-Agent: ${CLAUDECODE:+claude-code}${CURSOR_AGENT:+cursor}${CODEX_SANDBOX:+codex}${GEMINI_CLI:+gemini-cli}" \
   -d '{
         "target_phone": "+15551234567",
         "brief": "Call this sports bar and find out (1) whether they are showing the USA vs Netherlands match today and (2) whether a reservation is needed. Read the answers back to confirm, thank them, and end.",
@@ -252,6 +260,7 @@ brief deterministically. Five intents:
 curl -s -X POST https://api.voygr.tech/calls \
   -H "X-API-Key: $PLACECALL_API_KEY" -H "Content-Type: application/json" \
   -H "X-Client-Surface: claude-plugin" \
+  -H "X-Client-Agent: ${CLAUDECODE:+claude-code}${CURSOR_AGENT:+cursor}${CODEX_SANDBOX:+codex}${GEMINI_CLI:+gemini-cli}" \
   -d '{"target_phone": "+15551234567", "intent": "info_gathering",
        "language": "en", "ask_user_mode": "stream",
        "slots": {"target_phone": "+15551234567",
@@ -364,6 +373,7 @@ asked).
 curl -s -X POST https://api.voygr.tech/calls \
   -H "X-API-Key: $PLACECALL_API_KEY" -H "Content-Type: application/json" \
   -H "X-Client-Surface: claude-plugin" \
+  -H "X-Client-Agent: ${CLAUDECODE:+claude-code}${CURSOR_AGENT:+cursor}${CODEX_SANDBOX:+codex}${GEMINI_CLI:+gemini-cli}" \
   -d '{
         "target_phone": "<card phone_e164>",
         "brief": "<card call_brief — as-is, or edited>",


### PR DESCRIPTION
Adds the `X-Client-Agent` request header to the call-placing examples in `skills/call/SKILL.md` (and the matching `README.md` / `AGENTS.md` examples), beside the existing `X-Client-Surface`.

## Why
callwright now records WHICH TOOL placed each call (#574-b) — the sibling axis to origin (which listing produced the customer). The carrier is an `X-Client-Agent` request header. This teaches the distributed skill to set it from the caller's environment.

## The header
```
-H "X-Client-Agent: ${CLAUDECODE:+claude-code}${CURSOR_AGENT:+cursor}${CODEX_SANDBOX:+codex}${GEMINI_CLI:+gemini-cli}"
```
Each tool exports a distinct env var, so this expands to `claude-code` / `cursor` / `codex` / `gemini-cli` (callwright's vocabulary, lowercase). Telemetry only — never affects auth, billing or the call. If none is set the header is empty and callwright falls back to the User-Agent.

## Scope
Docs only. Added to every `POST /calls` example; deliberately NOT added to `POST /calls/{id}/answer` (a mid-call reply, not a call placement, and it carries no `X-Client-Surface` either). No behaviour change on the client side; the header only takes effect once the gateway forwards it (separate poi_enrichment change).