### PR TITLE
docs(skill): the outcome list called itself complete and was missing seven of seventeen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,24 +103,44 @@ header (the param wins and survives proxies that strip the header). On
 `event: ask_user` → answer promptly via `POST /calls/{id}/answer`
 `{"request_id","answer"}` (the bot waits a bounded window, then proceeds
 without you; de-dup by `request_id` — the backfill can repeat). On
-`event: outcome` → terminal.
+`event: outcome` → terminal; its `data:` carries `result`, `ended_by`,
+`outcome_type`, `charge_cents`, `summary`.
 
 ## Get the result — `GET /calls/{id}`
-Returns `status`, `outcome_type`, `outcome_summary`, `transcript_full`.
+Returns `status`, the two outcome axes `result` + `ended_by`, `outcome_summary`,
+`outcome_charge_cents`, `transcript_full`.
 **⚠️ If `status` is terminal but `outcome_type`/`transcript_full` are `null`,
 keep polling every few seconds until `outcome_type` is non-null — the result
 persists just after the status flips.** Always report from `transcript_full`
-(`success_no_booking` = billable success: info obtained, no booking). Outcomes:
-`success_booked|success_refused|success_no_booking` (billed) ·
+(`success_no_booking` = billable success: info obtained, no booking).
+**The verdict is two fields.** `result` — did we get what we called for:
+`goal_met|goal_partial|refused|goal_not_met|wrong_party|not_reached|aborted`.
+`ended_by` — why the call stopped:
+`callee_hangup|agent_hangup|dropped|budget_timeout|dial_failed|customer_cancelled|system_error|compliance_stop`
+(`completed` is defined but nothing produces it). `null` on either is a real
+answer — "never established" — and every call finalized before 2026-08-25
+carries `null` on both. Branch on these two, not on the string below.
+**`outcome_type` is deprecated** — one string answering three unrelated
+questions, kept with no removal date as a correlation aid for log searches and
+`outcome_type=` filters. All seventeen, verbatim:
+`success_booked|success_refused|success_no_booking|success_booking_cancelled` ·
 `failed_short_hangup` (most common failure — picked up, hung up early) ·
-`failed_voicemail|failed_no_answer|failed_busy|failed_no_agent_available|failed_no_disclosure|failed_technical` (all free).
+`failed_voicemail|failed_no_answer|failed_busy|failed_no_agent_available|failed_no_disclosure|failed_technical` ·
+`failed_call_dropped` (line died after real dialogue) · `failed_wrong_number`
+(answered, not the business you asked for) · `failed_cancelled` (you cancelled
+the call — not the same as `success_booking_cancelled`, where the venue
+cancelled the booking) · `failed_no_engagement` (answered, every reply a
+listening noise) · `failed_agent_mute` (answered, our agent never spoke) ·
+`failed_language_barrier` (unsupported language; nothing emits it yet).
 Recording: when `has_recording` is true, GET `recording_url` (relative path)
 with your API key to download the audio. Merged post-call transcript:
 `GET /calls/{id}/transcript-merged`. Cancel a call: `POST /calls/{id}/cancel`.
 
 ## Credits & errors
 `GET /v1/usage` → remaining (or `GET /users/me` → `credits_available`).
-**Only `success_*` outcomes are billed; every `failed_*` costs nothing.**
+**The `success_`/`failed_` prefix is a billing family, not the money answer:**
+`failed_call_dropped` is charged, and so is `failed_cancelled` once the callee
+picked up; every other `failed_*` costs nothing. Read `outcome_charge_cents`.
 Each call takes a refundable hold at dial time that is larger than the charge,
 settled to the charge on success and refunded in full on failure, so `402` can
 fire while the balance still looks sufficient for the charge alone. Rates and

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -451,7 +451,9 @@ done
   with `LAST=` the printed value to wait for the outcome. The bot waits a
   bounded window (~60s), then proceeds without you — answer promptly. The
   backfill can repeat events, so **de-dup `ask_user` by `request_id`**.
-- `### OUTCOME ###` → terminal; report `outcome_type` + `summary`.
+- `### OUTCOME ###` → terminal; report `result` + `ended_by` + `summary` from
+  the `data:` JSON. It also carries the deprecated `outcome_type` and
+  `charge_cents`.
 - Other event types you may see: `status_change`, `recording_ready`,
   `transcript_ready`. `503 too_many_sse_streams` → back off per `Retry-After`.
 
@@ -467,7 +469,8 @@ not treat it as success.
 
 ## Get the result — `GET /calls/{call_id}`
 
-Returns `status`, `outcome_type`, `outcome_summary`, and `transcript_full`.
+Returns `status`, the two outcome axes `result` + `ended_by`,
+`outcome_summary`, `outcome_charge_cents`, and `transcript_full`.
 
 ```sh
 curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/calls/$ID
@@ -487,17 +490,80 @@ curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/calls/$ID
   **relative** path (`/calls/{id}/recording`) — prepend the base URL and fetch
   with the same `X-API-Key` to download the audio.
 
-**Outcome types (all of them — your agent WILL meet every one):**
-- `success_booked` / `success_refused` / `success_no_booking` — a real
-  conversation happened (booked / venue said no / info obtained). Billed.
+### The verdict is two fields, not one string
+
+Read `result` and `ended_by` separately — they answer different questions, and a
+call can be any combination of the two.
+
+**`result`** — did we get what we called for:
+- `goal_met` — everything the brief asked for.
+- `goal_partial` — some of it, not all.
+- `refused` — they understood and declined.
+- `goal_not_met` — we reached them and got nothing.
+- `wrong_party` — someone answered, but not the business you asked for.
+- `not_reached` — nobody able to answer was ever on the line.
+- `aborted` — we stopped it (error, compliance gate, your cancel).
+
+**`ended_by`** — why the call stopped. A telephony fact, not a verdict:
+`callee_hangup`, `agent_hangup`, `dropped`, `budget_timeout`, `dial_failed`,
+`customer_cancelled`, `system_error`, `compliance_stop`. (`completed` is in the
+vocabulary but nothing produces it today — don't wait for it.)
+
+> Either field can be `null`, and that is a **real answer** meaning "we never
+> established this" — not a placeholder, and there is no `unknown` member.
+> Calls finalized before 2026-08-25 carry `null` on both.
+
+### `outcome_type` — deprecated, but still returned
+
+One string forced to answer three unrelated questions at once (who picked up,
+whether we succeeded, whether we charge), so it can only ever be right about
+one of them: `failed_no_answer` has come back for calls a human answered and
+spoke on. **Branch on `result` + `ended_by`.** Keep `outcome_type` for
+correlating with an older log line or an `outcome_type=` filter — which is why
+the values below are spelled exactly as the API returns them.
+
+There is **no removal date**, and all seventeen values are live:
+
+- `success_booked` — the reservation was confirmed.
+- `success_refused` — a real conversation, and the venue said no (closed, full,
+  policy).
+- `success_no_booking` — information obtained, no booking attempt completed.
+  The answer lives in the transcript, so report from it.
+- `success_booking_cancelled` — you asked us to cancel a reservation and the
+  venue confirmed it. **Not** `failed_cancelled`: this is the *venue* cancelling
+  the *booking*, that one is *you* cancelling the *call*.
 - `failed_short_hangup` — **the most common failure**: someone picked up but
-  hung up before a real conversation (often right after the AI disclosure). Free.
-- `failed_voicemail`, `failed_no_answer`, `failed_busy` — nobody reached. Free.
-- `failed_no_agent_available` — a hold queue played music past the hold budget
-  and no human ever picked up. Free.
+  hung up before a real conversation, often right after the AI disclosure.
+- `failed_voicemail`, `failed_no_answer`, `failed_busy` — nobody reached.
+- `failed_no_agent_available` — a hold queue played past the hold budget and no
+  human ever picked up.
 - `failed_no_disclosure` — the mandatory recording/AI notice couldn't be
-  delivered (or the callee hung up during it), so the call ended early. Free.
-- `failed_technical` — carrier/system error, incl. reaching a wrong business. Free.
+  delivered (or the callee hung up during it), so the call ended early.
+- `failed_technical` — carrier or system error.
+- `failed_call_dropped` — the line died mid-conversation *after* real dialogue,
+  classically while we were being transferred. Distinct from
+  `failed_short_hangup`, and charged: the conversation did happen.
+- `failed_wrong_number` — the line answered, but it wasn't the business you
+  asked for (a recycled number, a private individual, a robocall). The agent
+  apologises and leaves rather than arguing.
+- `failed_cancelled` — you cancelled the call yourself via
+  `POST /calls/{id}/cancel` before it produced an outcome.
+- `failed_no_engagement` — somebody answered and spoke, but every reply was a
+  listening noise ("uh-huh", "okay") and not one item of your brief was ever
+  answered. Count it as **connected**: a person really did pick up.
+- `failed_agent_mute` — the mirror of the one above: somebody answered and
+  **our** agent never said a word to them, classically after a phone tree handed
+  us to a person our side didn't notice arrive. Worth redialling — nothing was
+  ever asked.
+- `failed_language_barrier` — a person was there, but nothing could cross
+  because they spoke a language outside the set our speech recognition covers.
+  **Nothing produces this value yet**; detecting the condition is open work.
+
+> ⚠️ **The `success_` / `failed_` prefix is a billing family, not the money
+> answer.** Two `failed_*` outcomes cost credits: `failed_call_dropped` always,
+> and `failed_cancelled` when you cancel a call the callee had already picked
+> up. Read **`outcome_charge_cents`** (`10` or `0`) when you need the number —
+> never the name.
 
 ## Other endpoints
 
@@ -514,8 +580,10 @@ curl -s -H "X-API-Key: $PLACECALL_API_KEY" https://api.voygr.tech/v1/usage
 # {"remaining":...,"quota_limit":...,"current_usage":...,"tier":...}
 ```
 **Two things bill, and both draw on one balance.** Calls: a `success_*` outcome
-costs credits, every `failed_*` outcome costs nothing, so voicemails, hangups
-and busy lines do not burn quota. Place suggestions: 5 credits per answered
+costs credits, and so do the two `failed_*` outcomes noted above
+(`failed_call_dropped`, and `failed_cancelled` once the callee has picked up);
+every other `failed_*` outcome costs nothing, so voicemails, unanswered lines
+and busy signals do not burn quota. Place suggestions: 5 credits per answered
 `POST /v1/places/suggest`, nothing for a refusal (see
 [Suggest errors](#suggest-errors)). **The free tier is one shared pot:** the
 250 free calls are 2,500 credits, and suggestions draw on the same 2,500 — so

--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -664,6 +664,7 @@ it was and give the fix:
    `call_brief`).
 2. `POST /calls` → capture the `call_id` (`call.call_id` on the freeform path).
 3. Run the poll loop; answer any `ask_user` promptly, then re-poll.
-4. On outcome, poll `GET /calls/{id}` until `outcome_type` is non-null, then
-   read `outcome_type` + `outcome_summary` + `transcript_full`. Report the
+4. On outcome, poll `GET /calls/{id}` until `outcome_type` is non-null (it is
+   the column that lands last, so it is the readiness signal), then read
+   `result` + `ended_by` + `outcome_summary` + `transcript_full`. Report the
    transcript reality, not just the code.


### PR DESCRIPTION
## What was already fixed here, and what was not

Issue #872 landed in this repo on 2026-09-03 (#29): the "Free ... ever" claim
about `POST /v1/places/suggest` was corrected, and the places card's honesty
rewrite (`price_band`, `confidence`, no `rating` / `review_count` /
`price_level`) is in. That work is real and is not touched here.

**A different gap in the same file was never touched.** `skills/call/SKILL.md`
says verbatim:

> **Outcome types (all of them — your agent WILL meet every one):**

and then lists **ten** of the **seventeen** values `CallOutcomeType` emits.

## The drift, measured

Against `voygr-tech/callwright` @ `master`, `callwright/domain/call.py`:

| | |
|---|---|
| values in `CallOutcomeType` | **17** |
| values documented in `skills/call/SKILL.md` | **10** |
| `ended_by` occurrences in the file | **0** |
| `result` VALUES in the file | **0** (the three `result` hits were the ordinary English word) |
| deprecation markers | **0** |

**The seven that were missing:** `failed_call_dropped`, `failed_wrong_number`,
`failed_cancelled`, `failed_no_engagement`, `failed_agent_mute`,
`success_booking_cancelled`, `failed_language_barrier`.

Two of them — `success_booking_cancelled` and `failed_language_barrier` — were
added by callwright #1242 on 2026-09-08, so the gap was widening while this
file claimed completeness. A client agent that meets `failed_agent_mute` gets a
value its own instructions promise cannot exist.

`AGENTS.md` carried the identical ten-value list, closed `(all free)`. Codex
installs are frozen copies taken at install time, so it is fixed in the same
pass — the same reasoning #29 used for touching it.

## What changed

**The two axes are now the verdict.** `result` (7 values) and `ended_by`
(9 values) have been the answer since 2026-08-25 and are served on the public
call object (`docs/api/calls.md`, response example and field table). Neither
appeared here at all. Wording follows the three callwright docs that already
say this rather than inventing a new framing: `docs/api/calls.md`,
`docs/AI_AGENT_SKILL_API.md` §*Outcome*, and `mcp-server/README.md`.

**`outcome_type` is kept, marked deprecated, and completed to all seventeen** —
"still returned, no removal date", as a correlation aid. Each value gets a
one-line meaning taken from `docs/api/lifecycle.md`, not invented.

**The values keep their exact spelling.** `success_booked`, underscore intact,
no prose softening — correlating means pasting the string into a log search or
an `outcome_type=` filter, so a "prettified" spelling would defeat the only
reason the field is still documented.

**A billing correction the addition forced.** Both files claimed every
`failed_*` outcome is free. That is false for two of the seven being added:
`failed_call_dropped` is billed at the 10-credit rate by default (the
conversation did happen), and `failed_cancelled` is charged once the callee has
picked up (`docs/api/lifecycle.md`, the pricing table and the exception below
it). The `success_` / `failed_` prefix is a billing *family*, not the money
answer — `outcome_charge_cents` is. Publishing the seven under an unqualified
"all free" heading would have added a fresh false claim about the very values
being fixed, so the claim is qualified in both files.

**One more stale line:** `failed_technical` was documented as including
"reaching a wrong business". That has been `failed_wrong_number` since
callwright #509 — one of the seven that were missing.

## What this PR deliberately does not do

The task that produced this also asked for the **#789 item 4** places-card gap
(`verify_items`, `call_needed`, `online_route`, `fit_note`,
`REGION_NOT_SUPPORTED`) in the same file. **That work already exists here, in
draft PR #30**, done properly and field-for-field. Opening a rival would be
worse than leaving it, so this PR touches nothing in the suggest section, and
the two diffs do not overlap.

Worth knowing: **#30's stated blocker has cleared.** It is a draft "until
`voygr-tech/callwright` `fix/788-past-tense-route-vocab` merges" — that branch
merged as callwright **#1315 on 2026-09-04T08:46Z**, about 30 minutes after #30
was last updated. It has sat as a draft since. It needs a re-check against
master and un-drafting, by someone who can verify its `online_route`
vocabulary claim.

## No version bump

Following #29, the previous corrective docs pass of exactly this kind, which
bumped nothing. #30 already claims `6.1.0`; this change is disjoint from it in
the file and should not race it for a version number.

## Verification

- Every one of the 17 `CallOutcomeType` values, all 7 `CallResult` values and
  all 9 `CallEndedBy` values appear in **both** files, checked by parsing the
  enums out of callwright master and regex-matching each value inside a code
  span. Result: `17/17`, `7/7`, `9/9` in each file, zero missing.
- No occurrence of the retired claims remains in either file:
  "every `failed_*` outcome costs nothing", "every `failed_*` costs nothing",
  "(all free)", "all of them".
- Nothing outside the outcome and credits sections is touched; the suggest
  section is byte-identical, so #30 rebases cleanly.
- No API calls were made and no cluster was touched.
- This repo has no CI workflow on `main` and no automated reviewer, so this is
  human review only.

## Left

- **ClawHub republication is a manual operator step.** Merging changes the
  repo, not the published listing.
- **Draft #30**, above — unblocked, not mine to un-draft.
- A guard so this cannot silently drift again is a **separate PR in
  `voygr-tech/callwright`**, since that is where the enum lives.

Refs voygr-tech/callwright#1242, #509, #789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
