### PR TITLE
docs(skill): the intro counted 14 outcomes while the list below named all seventeen

### DIFF
--- a/skills/call/SKILL.md
+++ b/skills/call/SKILL.md
@@ -52,7 +52,7 @@ then gets things done. If necessary - agents will ask questions mid-call.
 
 ## What You Get Back
 
-Every call returns one of 14 verified outcomes, plus the full transcript and
+Every call returns one of 17 verified outcomes, plus the full transcript and
 recording - including clear failure reasons like dropped calls, busy lines,
 voicemail, or wrong numbers.
 


### PR DESCRIPTION
`CallOutcomeType` in `voygr-tech/callwright` (`callwright/domain/call.py`) has **17** members. PR #31 corrected the detailed list to name every one of them, and to lead with the `result` + `ended_by` axes — but left the *What You Get Back* intro claiming **14**, so the same file stated two different counts.

Verified by importing the enum rather than by reading it:

```
CallOutcomeType members: 17
success_booked, success_refused, success_no_booking, success_booking_cancelled,
failed_voicemail, failed_no_answer, failed_busy, failed_short_hangup,
failed_technical, failed_no_agent_available, failed_no_disclosure,
failed_call_dropped, failed_wrong_number, failed_cancelled,
failed_no_engagement, failed_agent_mute, failed_language_barrier
```

The seventeen names in this file's detailed list match that set exactly.

One line changed. The framing question — whether marketing copy should lead with a count of a **deprecated** field at all, rather than with the two live axes — is deliberately left alone here; it is a copy decision with an owner, not a correctness fix.